### PR TITLE
Fix and simplify typing for tasks and engines

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sieves
-version = 0.3.0
+version = 0.4.0
 author = Matthew Upson, Nick Sorros, Raphael Mitsch, Matthew Maufe, Angelo Di Gianvito
 author_email = hi@mantisnlp.com
 long_description = file: README.md

--- a/sieves/engines/core.py
+++ b/sieves/engines/core.py
@@ -66,7 +66,7 @@ class Engine(Generic[EnginePromptSignature, EngineResult, Model, EngineInference
         self,
         inference_mode: EngineInferenceMode,
         prompt_template: str | None,
-        prompt_signature: EnginePromptSignature,
+        prompt_signature: type[EnginePromptSignature] | EnginePromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = (),
     ) -> Executable[EngineResult | None]:
         """
@@ -74,7 +74,7 @@ class Engine(Generic[EnginePromptSignature, EngineResult, Model, EngineInference
         generators are e.g. Predict in DSPy, generator in outlines, Jsonformer in jsonformers).
         :param inference_mode: Inference mode to use (e.g. classification, JSON, ... - this is engine-specific).
         :param prompt_template: Prompt template.
-        :param prompt_signature: Expected prompt signature.
+        :param prompt_signature: Expected prompt signature type.
         :param fewshot_examples: Few-shot examples.
         :return: Prompt executable.
         """

--- a/sieves/engines/dspy_.py
+++ b/sieves/engines/dspy_.py
@@ -8,7 +8,7 @@ import pydantic
 
 from sieves.engines.core import Engine, Executable
 
-PromptSignature: TypeAlias = type[dspy.Signature] | type[dspy.Module]
+PromptSignature: TypeAlias = dspy.Signature | dspy.Module
 Model: TypeAlias = dsp.LM | dspy.BaseLM
 Result: TypeAlias = dspy.Prediction
 
@@ -66,7 +66,7 @@ class DSPy(Engine[PromptSignature, Result, Model, InferenceMode]):
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,  # noqa: UP007
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = tuple(),
     ) -> Executable[Result | None]:
         # Note: prompt_template is ignored here, as DSPy doesn't use it directly (only prompt_signature_description).

--- a/sieves/engines/glix_.py
+++ b/sieves/engines/glix_.py
@@ -36,7 +36,7 @@ class GliX(Engine[PromptSignature, Result, Model, InferenceMode]):
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = (),
     ) -> Executable[Result]:
         cls_name = self.__class__.__name__

--- a/sieves/engines/huggingface_.py
+++ b/sieves/engines/huggingface_.py
@@ -32,7 +32,7 @@ class HuggingFace(Engine[PromptSignature, Result, Model, InferenceMode]):
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = (),
     ) -> Executable[Result | None]:
         cls_name = self.__class__.__name__

--- a/sieves/engines/langchain_.py
+++ b/sieves/engines/langchain_.py
@@ -8,7 +8,7 @@ import pydantic
 from sieves.engines.core import Executable, TemplateBasedEngine
 
 Model: TypeAlias = langchain_core.language_models.BaseChatModel
-PromptSignature: TypeAlias = type[pydantic.BaseModel]
+PromptSignature: TypeAlias = pydantic.BaseModel
 Result: TypeAlias = pydantic.BaseModel
 
 
@@ -31,7 +31,7 @@ class LangChain(TemplateBasedEngine[PromptSignature, Result, Model, InferenceMod
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,  # noqa: UP007
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = tuple(),
     ) -> Executable[Result | None]:
         cls_name = self.__class__.__name__

--- a/sieves/engines/ollama_.py
+++ b/sieves/engines/ollama_.py
@@ -14,7 +14,7 @@ class Model(pydantic.BaseModel):
     client: ollama.Client
 
 
-PromptSignature: TypeAlias = type[pydantic.BaseModel]
+PromptSignature: TypeAlias = pydantic.BaseModel
 Result: TypeAlias = pydantic.BaseModel
 
 
@@ -42,7 +42,7 @@ class Ollama(TemplateBasedEngine[PromptSignature, Result, Model, InferenceMode])
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,  # noqa: UP007
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = tuple(),
     ) -> Executable[Result | None]:
         cls_name = self.__class__.__name__

--- a/sieves/engines/outlines_.py
+++ b/sieves/engines/outlines_.py
@@ -8,7 +8,7 @@ from outlines.models import MLXLM, ExLlamaV2Model, LlamaCpp, OpenAI, Transformer
 
 from sieves.engines.core import Executable, TemplateBasedEngine
 
-PromptSignature: TypeAlias = type[pydantic.BaseModel] | list[str] | str
+PromptSignature: TypeAlias = pydantic.BaseModel | list[str] | str
 Model: TypeAlias = ExLlamaV2Model | LlamaCpp | MLXLM | OpenAI | TransformersVision | Transformers
 Result: TypeAlias = pydantic.BaseModel | str
 
@@ -42,7 +42,7 @@ class Outlines(TemplateBasedEngine[PromptSignature, Result, Model, InferenceMode
         self,
         inference_mode: InferenceMode,
         prompt_template: str | None,  # noqa: UP007
-        prompt_signature: PromptSignature,
+        prompt_signature: type[PromptSignature] | PromptSignature,
         fewshot_examples: Iterable[pydantic.BaseModel] = (),
     ) -> Executable[Result | None]:
         cls_name = self.__class__.__name__

--- a/sieves/tasks/core.py
+++ b/sieves/tasks/core.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Iterable
-from typing import Any, Generic, TypeVar
-
-import pydantic
+from typing import Any, TypeVar
 
 from sieves.data import Doc
 from sieves.serialization import Attribute, Config
@@ -12,7 +10,6 @@ from sieves.serialization import Attribute, Config
 TaskPromptSignature = TypeVar("TaskPromptSignature", covariant=True)
 TaskInferenceMode = TypeVar("TaskInferenceMode", covariant=True)
 TaskResult = TypeVar("TaskResult")
-TaskFewshotExample = TypeVar("TaskFewshotExample", bound=pydantic.BaseModel)
 
 
 class Task(abc.ABC):
@@ -69,74 +66,3 @@ class Task(abc.ABC):
         """
         # Deserialize and inject engine.
         return cls(**config.to_init_dict(cls, **kwargs))
-
-
-class Bridge(Generic[TaskPromptSignature, TaskInferenceMode, TaskResult], abc.ABC):
-    def __init__(self, task_id: str, prompt_template: str | None, prompt_signature_desc: str | None):
-        """
-        Initializes new bridge.
-        :param task_id: Task ID.
-        :param prompt_template: Custom prompt template. If None, default will be used.
-        :param prompt_signature_desc: Custom prompt signature description. If None, default will be used.
-        """
-        self._task_id = task_id
-        self._custom_prompt_template = prompt_template
-        self._custom_prompt_signature_desc = prompt_signature_desc
-
-    @property
-    @abc.abstractmethod
-    def prompt_template(self) -> str | None:
-        """Returns prompt template.
-        Note: different engines have different expectations as how a prompt should look like. E.g. outlines supports the
-        Jinja 2 templating format for insertion of values and few-shot examples, whereas DSPy integrates these things in
-        a different value in the workflow and hence expects the prompt not to include these things. Mind engine-specific
-        expectations when creating a prompt template.
-        :returns: Prompt template as string. None if not used by engine.
-        """
-
-    @property
-    @abc.abstractmethod
-    def prompt_signature_description(self) -> str | None:
-        """Returns prompt signature description. This is used by some engines to aid the language model in generating
-        structured output.
-        :returns: Prompt signature description. None if not used by engine.
-        """
-
-    @property
-    @abc.abstractmethod
-    def prompt_signature(self) -> TaskPromptSignature:
-        """Creates output signature (e.g.: `Signature` in DSPy, Pydantic objects in outlines, JSON schema in
-        jsonformers). This is engine-specific.
-        :returns: Output signature object.
-        """
-
-    @property
-    @abc.abstractmethod
-    def inference_mode(self) -> TaskInferenceMode:
-        """Returns inference mode.
-        :returns: Inference mode.
-        """
-
-    def extract(self, docs: Iterable[Doc]) -> Iterable[dict[str, Any]]:
-        """Extract all values from doc instances that are to be injected into the prompts.
-        :param docs: Docs to extract values from.
-        :returns: All values from doc instances that are to be injected into the prompts
-        """
-        return ({"text": doc.text if doc.text else None} for doc in docs)
-
-    @abc.abstractmethod
-    def integrate(self, results: Iterable[TaskResult], docs: Iterable[Doc]) -> Iterable[Doc]:
-        """Integrate results into Doc instances.
-        :param results: Results from prompt executable.
-        :param docs: Doc instances to update.
-        :returns: Updated doc instances.
-        """
-
-    @abc.abstractmethod
-    def consolidate(self, results: Iterable[TaskResult], docs_offsets: list[tuple[int, int]]) -> Iterable[TaskResult]:
-        """Consolidates results for document chunks into document results.
-        :param results: Results per document chunk.
-        :param docs_offsets: Chunk offsets per document. Chunks per document can be obtained with
-            results[docs_chunk_offsets[i][0]:docs_chunk_offsets[i][1]].
-        :returns: Results per document.
-        """

--- a/sieves/tasks/core.py
+++ b/sieves/tasks/core.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Iterable
-from typing import Any, TypeVar
+from typing import Any
 
 from sieves.data import Doc
 from sieves.serialization import Attribute, Config
-
-TaskPromptSignature = TypeVar("TaskPromptSignature", covariant=True)
-TaskInferenceMode = TypeVar("TaskInferenceMode", covariant=True)
-TaskResult = TypeVar("TaskResult")
 
 
 class Task(abc.ABC):

--- a/sieves/tasks/predictive/classification/bridges.py
+++ b/sieves/tasks/predictive/classification/bridges.py
@@ -10,7 +10,7 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import dspy_, glix_, huggingface_, langchain_, ollama_, outlines_
-from sieves.tasks.core import Bridge
+from sieves.tasks.predictive.core import Bridge
 
 BridgePromptSignature = TypeVar("BridgePromptSignature", covariant=True)
 BridgeInferenceMode = TypeVar("BridgeInferenceMode", bound=enum.Enum, covariant=True)

--- a/sieves/tasks/predictive/classification/bridges.py
+++ b/sieves/tasks/predictive/classification/bridges.py
@@ -1,7 +1,7 @@
 import abc
 from collections.abc import Iterable
 from functools import cached_property
-from typing import Literal, TypeVar
+from typing import Generic, Literal, TypeVar
 
 import dspy
 import jinja2
@@ -11,12 +11,14 @@ from sieves.data import Doc
 from sieves.engines import dspy_, glix_, huggingface_, langchain_, ollama_, outlines_
 from sieves.tasks.predictive.core import Bridge
 
-BridgePromptSignature = TypeVar("BridgePromptSignature", covariant=True)
-BridgeResult = TypeVar("BridgeResult")
+_BridgePromptSignature = TypeVar("_BridgePromptSignature", covariant=True)
+_BridgeResult = TypeVar("_BridgeResult")
 _GliXResult = list[dict[str, str | float]]
 
 
-class ClassificationBridge(Bridge[BridgePromptSignature, BridgeResult], abc.ABC):
+class ClassificationBridge(
+    Bridge[_BridgePromptSignature, _BridgeResult], Generic[_BridgePromptSignature, _BridgeResult], abc.ABC
+):
     def __init__(self, task_id: str, prompt_template: str | None, prompt_signature_desc: str | None, labels: list[str]):
         """
         Initializes InformationExtractionBridge.
@@ -48,7 +50,7 @@ class DSPyClassification(ClassificationBridge[dspy_.PromptSignature, dspy_.Resul
         )
 
     @cached_property
-    def prompt_signature(self) -> type[dspy_.PromptSignature]:  # type: ignore[valid-type]
+    def prompt_signature(self) -> type[dspy_.PromptSignature]:
         labels = self._labels
         # Dynamically create Literal as output type.
         LabelType = Literal[*labels]  # type: ignore[valid-type]
@@ -232,7 +234,7 @@ class GliXClassification(ClassificationBridge[list[str], _GliXResult]):
             yield sorted_label_scores
 
 
-class PydanticBasedClassification(ClassificationBridge[type[pydantic.BaseModel], pydantic.BaseModel], abc.ABC):
+class PydanticBasedClassification(ClassificationBridge[pydantic.BaseModel, pydantic.BaseModel], abc.ABC):
     @property
     def prompt_template(self) -> str | None:
         return (

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -11,7 +11,6 @@ from sieves.engines import Engine, EngineType, dspy_, glix_, huggingface_, outli
 from sieves.engines.core import EngineInferenceMode, EnginePromptSignature, EngineResult, Model
 from sieves.serialization import Config
 from sieves.tasks.predictive.classification.bridges import (
-    BridgeInferenceMode,
     BridgePromptSignature,
     BridgeResult,
     ClassificationBridge,
@@ -85,9 +84,7 @@ class Classification(PredictiveTask[TaskPromptSignature, TaskResult, Model, Task
         )
         self._fewshot_examples: Iterable[TaskFewshotExample]
 
-    def _init_bridge(
-        self, engine_type: EngineType
-    ) -> ClassificationBridge[BridgePromptSignature, BridgeInferenceMode, BridgeResult]:
+    def _init_bridge(self, engine_type: EngineType) -> ClassificationBridge[BridgePromptSignature, BridgeResult]:
         """Initialize engine task.
         :returns: Engine task.
         :raises ValueError: If engine type is not supported.

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -50,7 +50,7 @@ class TaskFewshotExample(pydantic.BaseModel):
         return self
 
 
-class Classification(PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode]):
+class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode]):
     def __init__(
         self,
         labels: list[str],

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -51,9 +51,7 @@ class TaskFewshotExample(pydantic.BaseModel):
         return self
 
 
-class Classification(
-    PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode, TaskFewshotExample],
-):
+class Classification(PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode]):
     def __init__(
         self,
         labels: list[str],
@@ -85,6 +83,7 @@ class Classification(
             prompt_signature_desc=prompt_signature_desc,
             fewshot_examples=fewshot_examples,
         )
+        self._fewshot_examples: Iterable[TaskFewshotExample]
 
     def _init_bridge(
         self, engine_type: EngineType

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -47,7 +47,7 @@ class TaskFewshotExample(pydantic.BaseModel):
         return self
 
 
-class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode, TaskBridge]):
+class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskBridge]):
     def __init__(
         self,
         labels: list[str],

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -11,15 +11,12 @@ from sieves.engines import Engine, EngineType, dspy_, glix_, huggingface_, outli
 from sieves.engines.core import EngineInferenceMode, EnginePromptSignature, EngineResult, Model
 from sieves.serialization import Config
 from sieves.tasks.predictive.classification.bridges import (
-    ClassificationBridge,
     DSPyClassification,
     GliXClassification,
     HuggingFaceClassification,
     LangChainClassification,
     OllamaClassification,
     OutlinesClassification,
-    _BridgePromptSignature,
-    _BridgeResult,
 )
 from sieves.tasks.predictive.core import PredictiveTask
 
@@ -50,7 +47,7 @@ class TaskFewshotExample(pydantic.BaseModel):
         return self
 
 
-class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode]):
+class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode, TaskBridge]):
     def __init__(
         self,
         labels: list[str],
@@ -84,7 +81,7 @@ class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferen
         )
         self._fewshot_examples: Iterable[TaskFewshotExample]
 
-    def _init_bridge(self, engine_type: EngineType) -> ClassificationBridge[_BridgePromptSignature, _BridgeResult]:
+    def _init_bridge(self, engine_type: EngineType) -> TaskBridge:
         """Initialize engine task.
         :returns: Engine task.
         :raises ValueError: If engine type is not supported.
@@ -108,7 +105,7 @@ class Classification(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferen
         except KeyError:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.")
 
-        return bridge  # type: ignore[return-value]
+        return bridge
 
     @property
     def supports(self) -> set[EngineType]:

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -11,8 +11,6 @@ from sieves.engines import Engine, EngineType, dspy_, glix_, huggingface_, outli
 from sieves.engines.core import EngineInferenceMode, EnginePromptSignature, EngineResult, Model
 from sieves.serialization import Config
 from sieves.tasks.predictive.classification.bridges import (
-    BridgePromptSignature,
-    BridgeResult,
     ClassificationBridge,
     DSPyClassification,
     GliXClassification,
@@ -20,10 +18,12 @@ from sieves.tasks.predictive.classification.bridges import (
     LangChainClassification,
     OllamaClassification,
     OutlinesClassification,
+    _BridgePromptSignature,
+    _BridgeResult,
 )
 from sieves.tasks.predictive.core import PredictiveTask
 
-TaskPromptSignature: TypeAlias = list[str] | type[pydantic.BaseModel] | type[dspy_.PromptSignature]  # type: ignore[valid-type]
+TaskPromptSignature: TypeAlias = list[str] | pydantic.BaseModel | dspy_.PromptSignature
 TaskInferenceMode: TypeAlias = (
     outlines_.InferenceMode | dspy_.InferenceMode | huggingface_.InferenceMode | glix_.InferenceMode
 )
@@ -84,7 +84,7 @@ class Classification(PredictiveTask[TaskPromptSignature, TaskResult, Model, Task
         )
         self._fewshot_examples: Iterable[TaskFewshotExample]
 
-    def _init_bridge(self, engine_type: EngineType) -> ClassificationBridge[BridgePromptSignature, BridgeResult]:
+    def _init_bridge(self, engine_type: EngineType) -> ClassificationBridge[_BridgePromptSignature, _BridgeResult]:
         """Initialize engine task.
         :returns: Engine task.
         :raises ValueError: If engine type is not supported.

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import enum
 from collections.abc import Iterable
 from typing import Any, Generic
 
@@ -60,7 +61,7 @@ class PredictiveTask(
         """
 
     @abc.abstractmethod
-    def _init_bridge(self, engine_type: EngineType) -> Bridge[TaskPromptSignature, TaskInferenceMode, TaskResult]:
+    def _init_bridge(self, engine_type: EngineType) -> Bridge[TaskPromptSignature, TaskResult]:
         """Initialize engine task.
         :returns: Engine task.
         """
@@ -175,7 +176,7 @@ class PredictiveTask(
         """
 
 
-class Bridge(Generic[TaskPromptSignature, TaskInferenceMode, TaskResult], abc.ABC):
+class Bridge(Generic[TaskPromptSignature, TaskResult], abc.ABC):
     def __init__(self, task_id: str, prompt_template: str | None, prompt_signature_desc: str | None):
         """
         Initializes new bridge.
@@ -216,7 +217,7 @@ class Bridge(Generic[TaskPromptSignature, TaskInferenceMode, TaskResult], abc.AB
 
     @property
     @abc.abstractmethod
-    def inference_mode(self) -> TaskInferenceMode:
+    def inference_mode(self) -> enum.Enum:
         """Returns inference mode.
         :returns: Inference mode.
         """

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -209,10 +209,11 @@ class Bridge(Generic[TaskPromptSignature, TaskResult], abc.ABC):
 
     @property
     @abc.abstractmethod
-    def prompt_signature(self) -> TaskPromptSignature:
+    def prompt_signature(self) -> type[TaskPromptSignature] | TaskPromptSignature:
         """Creates output signature (e.g.: `Signature` in DSPy, Pydantic objects in outlines, JSON schema in
         jsonformers). This is engine-specific.
-        :returns: Output signature object.
+        :returns: Output signature object. This can be an instance (e.g. a regex string) or a class (e.g. a Pydantic
+            class).
         """
 
     @property

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -22,7 +22,7 @@ from sieves.tasks.core import Task, TaskInferenceMode, TaskPromptSignature, Task
 
 
 class PredictiveTask(
-    Generic[TaskPromptSignature, TaskResult, Model, TaskInferenceMode],
+    Generic[TaskPromptSignature, TaskResult, TaskInferenceMode],
     Task,
     abc.ABC,
 ):
@@ -150,7 +150,7 @@ class PredictiveTask(
     @classmethod
     def deserialize(
         cls, config: Config, **kwargs: dict[str, Any]
-    ) -> PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode]:
+    ) -> PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode]:
         """Generate PredictiveTask instance from config.
         :param config: Config to generate instance from.
         :param kwargs: Values to inject into loaded config.

--- a/sieves/tasks/predictive/information_extraction/bridges.py
+++ b/sieves/tasks/predictive/information_extraction/bridges.py
@@ -8,7 +8,7 @@ import jinja2
 import pydantic
 
 from sieves.data import Doc
-from sieves.engines import dspy_, langchain_, ollama_, outlines_
+from sieves.engines import EngineInferenceMode, dspy_, langchain_, ollama_, outlines_
 from sieves.tasks.predictive.core import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature", covariant=True)
@@ -16,7 +16,7 @@ _BridgeResult = TypeVar("_BridgeResult")
 
 
 class InformationExtractionBridge(
-    Bridge[_BridgePromptSignature, _BridgeResult],
+    Bridge[_BridgePromptSignature, _BridgeResult, EngineInferenceMode],
     abc.ABC,
 ):
     def __init__(
@@ -37,7 +37,7 @@ class InformationExtractionBridge(
         self._entity_type = entity_type
 
 
-class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignature, dspy_.Result]):
+class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignature, dspy_.Result, dspy_.InferenceMode]):
     @property
     def prompt_template(self) -> str | None:
         return self._custom_prompt_template
@@ -107,7 +107,7 @@ class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignatur
 
 
 class PydanticBasedInformationExtraction(
-    InformationExtractionBridge[pydantic.BaseModel, pydantic.BaseModel],
+    InformationExtractionBridge[pydantic.BaseModel, pydantic.BaseModel, EngineInferenceMode],
     abc.ABC,
 ):
     @property
@@ -189,19 +189,19 @@ class PydanticBasedInformationExtraction(
             yield self.prompt_signature(entities=entities, reasoning=str(reasonings))
 
 
-class OutlinesInformationExtraction(PydanticBasedInformationExtraction):
+class OutlinesInformationExtraction(PydanticBasedInformationExtraction[outlines_.InferenceMode]):
     @property
     def inference_mode(self) -> outlines_.InferenceMode:
         return outlines_.InferenceMode.json
 
 
-class OllamaInformationExtraction(PydanticBasedInformationExtraction):
+class OllamaInformationExtraction(PydanticBasedInformationExtraction[ollama_.InferenceMode]):
     @property
     def inference_mode(self) -> ollama_.InferenceMode:
         return ollama_.InferenceMode.chat
 
 
-class LangChainInformationExtraction(PydanticBasedInformationExtraction):
+class LangChainInformationExtraction(PydanticBasedInformationExtraction[langchain_.InferenceMode]):
     @property
     def inference_mode(self) -> langchain_.InferenceMode:
         return langchain_.InferenceMode.structured_output

--- a/sieves/tasks/predictive/information_extraction/bridges.py
+++ b/sieves/tasks/predictive/information_extraction/bridges.py
@@ -1,8 +1,7 @@
 import abc
-import enum
 from collections.abc import Iterable
 from functools import cached_property
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 import dspy
 import jinja2
@@ -13,13 +12,11 @@ from sieves.engines import dspy_, langchain_, ollama_, outlines_
 from sieves.tasks.predictive.core import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature", covariant=True)
-_BridgeInferenceMode = TypeVar("_BridgeInferenceMode", bound=enum.Enum, covariant=True)
-_PydanticBridgeInferenceMode = TypeVar("_PydanticBridgeInferenceMode", bound=enum.Enum, covariant=True)
 _BridgeResult = TypeVar("_BridgeResult")
 
 
 class InformationExtractionBridge(
-    Bridge[_BridgePromptSignature, _BridgeInferenceMode, _BridgeResult],
+    Bridge[_BridgePromptSignature, _BridgeResult],
     abc.ABC,
 ):
     def __init__(
@@ -40,7 +37,7 @@ class InformationExtractionBridge(
         self._entity_type = entity_type
 
 
-class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignature, dspy_.InferenceMode, dspy_.Result]):
+class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignature, dspy_.Result]):
     @property
     def prompt_template(self) -> str | None:
         return self._custom_prompt_template
@@ -110,8 +107,7 @@ class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignatur
 
 
 class PydanticBasedInformationExtraction(
-    InformationExtractionBridge[type[pydantic.BaseModel], _PydanticBridgeInferenceMode, pydantic.BaseModel],
-    Generic[_PydanticBridgeInferenceMode],
+    InformationExtractionBridge[type[pydantic.BaseModel], pydantic.BaseModel],
     abc.ABC,
 ):
     @property
@@ -193,19 +189,19 @@ class PydanticBasedInformationExtraction(
             yield self.prompt_signature(entities=entities, reasoning=str(reasonings))
 
 
-class OutlinesInformationExtraction(PydanticBasedInformationExtraction[outlines_.InferenceMode]):
+class OutlinesInformationExtraction(PydanticBasedInformationExtraction):
     @property
     def inference_mode(self) -> outlines_.InferenceMode:
         return outlines_.InferenceMode.json
 
 
-class OllamaInformationExtraction(PydanticBasedInformationExtraction[ollama_.InferenceMode]):
+class OllamaInformationExtraction(PydanticBasedInformationExtraction):
     @property
     def inference_mode(self) -> ollama_.InferenceMode:
         return ollama_.InferenceMode.chat
 
 
-class LangChainInformationExtraction(PydanticBasedInformationExtraction[langchain_.InferenceMode]):
+class LangChainInformationExtraction(PydanticBasedInformationExtraction):
     @property
     def inference_mode(self) -> langchain_.InferenceMode:
         return langchain_.InferenceMode.structured_output

--- a/sieves/tasks/predictive/information_extraction/bridges.py
+++ b/sieves/tasks/predictive/information_extraction/bridges.py
@@ -10,7 +10,7 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import dspy_, langchain_, ollama_, outlines_
-from sieves.tasks.core import Bridge
+from sieves.tasks.predictive.core import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature", covariant=True)
 _BridgeInferenceMode = TypeVar("_BridgeInferenceMode", bound=enum.Enum, covariant=True)

--- a/sieves/tasks/predictive/information_extraction/bridges.py
+++ b/sieves/tasks/predictive/information_extraction/bridges.py
@@ -52,7 +52,7 @@ class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignatur
         )
 
     @cached_property
-    def prompt_signature(self) -> type[dspy_.PromptSignature]:  # type: ignore[valid-type]
+    def prompt_signature(self) -> type[dspy_.PromptSignature]:
         extraction_type = self._entity_type
 
         class Entities(dspy.Signature):  # type: ignore[misc]
@@ -107,7 +107,7 @@ class DSPyInformationExtraction(InformationExtractionBridge[dspy_.PromptSignatur
 
 
 class PydanticBasedInformationExtraction(
-    InformationExtractionBridge[type[pydantic.BaseModel], pydantic.BaseModel],
+    InformationExtractionBridge[pydantic.BaseModel, pydantic.BaseModel],
     abc.ABC,
 ):
     @property

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -38,7 +38,7 @@ class TaskFewshotExample(pydantic.BaseModel):
     entities: list[pydantic.BaseModel]
 
 
-class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode, TaskBridge]):
+class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, TaskBridge]):
     def __init__(
         self,
         entity_type: type[pydantic.BaseModel],

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -78,9 +78,7 @@ class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, Mode
             fewshot_examples=fewshot_examples,
         )
 
-    def _init_bridge(
-        self, engine_type: EngineType
-    ) -> InformationExtractionBridge[TaskPromptSignature, TaskInferenceMode, TaskResult]:
+    def _init_bridge(self, engine_type: EngineType) -> InformationExtractionBridge[TaskPromptSignature, TaskResult]:
         """Initialize engine task.
         :returns: Engine task.
         :raises ValueError: If engine type is not supported.

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -39,7 +39,7 @@ class TaskFewshotExample(pydantic.BaseModel):
     entities: list[pydantic.BaseModel]
 
 
-class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode]):
+class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode]):
     def __init__(
         self,
         entity_type: type[pydantic.BaseModel],

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -22,7 +22,7 @@ from sieves.tasks.predictive.information_extraction.bridges import (
 )
 from sieves.tasks.utils import PydanticToHFDatasets
 
-TaskPromptSignature: TypeAlias = type[pydantic.BaseModel] | type[dspy_.PromptSignature]  # type: ignore[valid-type]
+TaskPromptSignature: TypeAlias = pydantic.BaseModel | dspy_.PromptSignature
 TaskInferenceMode: TypeAlias = outlines_.InferenceMode | dspy_.InferenceMode | ollama_.InferenceMode
 TaskResult: TypeAlias = outlines_.Result | dspy_.Result | ollama_.Result
 TaskBridge: TypeAlias = (

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -15,7 +15,6 @@ from sieves.serialization import Config
 from sieves.tasks.predictive.core import PredictiveTask
 from sieves.tasks.predictive.information_extraction.bridges import (
     DSPyInformationExtraction,
-    InformationExtractionBridge,
     LangChainInformationExtraction,
     OllamaInformationExtraction,
     OutlinesInformationExtraction,
@@ -39,7 +38,7 @@ class TaskFewshotExample(pydantic.BaseModel):
     entities: list[pydantic.BaseModel]
 
 
-class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode]):
+class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, TaskInferenceMode, TaskBridge]):
     def __init__(
         self,
         entity_type: type[pydantic.BaseModel],
@@ -78,7 +77,7 @@ class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, Task
             fewshot_examples=fewshot_examples,
         )
 
-    def _init_bridge(self, engine_type: EngineType) -> InformationExtractionBridge[TaskPromptSignature, TaskResult]:
+    def _init_bridge(self, engine_type: EngineType) -> TaskBridge:
         """Initialize engine task.
         :returns: Engine task.
         :raises ValueError: If engine type is not supported.
@@ -102,15 +101,11 @@ class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, Task
         except KeyError:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.")
 
-        return bridge  # type: ignore[return-value]
+        return bridge
 
     @property
     def supports(self) -> set[EngineType]:
         return {EngineType.outlines, EngineType.dspy, EngineType.ollama}
-
-    def _validate_fewshot_examples(self) -> None:
-        # No fixed validation we can do here beyond what's already done by Pydantic.
-        pass
 
     @property
     def _state(self) -> dict[str, Any]:

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -39,9 +39,7 @@ class TaskFewshotExample(pydantic.BaseModel):
     entities: list[pydantic.BaseModel]
 
 
-class InformationExtraction(
-    PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode, TaskFewshotExample]
-):
+class InformationExtraction(PredictiveTask[TaskPromptSignature, TaskResult, Model, TaskInferenceMode]):
     def __init__(
         self,
         entity_type: type[pydantic.BaseModel],

--- a/sieves/tests/tasks/preprocessing/test_unstructured.py
+++ b/sieves/tests/tasks/preprocessing/test_unstructured.py
@@ -64,11 +64,11 @@ def test_serialization() -> None:
                     "partition": {"is_placeholder": True, "value": "builtins.function"},
                     "show_progress": {"is_placeholder": False, "value": True},
                     "task_id": {"is_placeholder": False, "value": "Unstructured"},
-                    "version": "0.3.0",
+                    "version": "0.4.0",
                 }
             ],
         },
-        "version": "0.3.0",
+        "version": "0.4.0",
     }
 
     deserialized_pipeline = Pipeline.deserialize(


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Fix and simplify typing for tasks and engines.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
Resolves #64.

## Changes Made
<!-- List key changes in this PR -->
- Fix incorrect typing for `Engine`, `Task`, `Bridge` and derived classes
- Simplify typing by dropping generics where possible.

The resulting type system is _barely_ simpler because I didn't see a way to drop more generics without weakening type checking and hints, but at least it's more correct and standardized.

## Checklist
- ~[ ] Tests have been extended to cover changes in functionality~
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
