### PR TITLE
Fix: adjust to DSPy update

### DIFF
--- a/sieves/engines/dspy_.py
+++ b/sieves/engines/dspy_.py
@@ -2,14 +2,13 @@ import enum
 from collections.abc import Iterable
 from typing import Any, TypeAlias
 
-import dsp
 import dspy
 import pydantic
 
 from sieves.engines.core import Engine, Executable
 
 _PromptSignature: TypeAlias = dspy.Signature | dspy.Module
-_Model: TypeAlias = dsp.LM | dspy.BaseLM
+_Model: TypeAlias = dspy.LM | dspy.BaseLM
 _Result: TypeAlias = dspy.Prediction
 
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Fixes change in DSPy update so that `LM` class is accessible via `dspy.LM` and not `dsp.LM`.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
\-

## Changes Made
<!-- List key changes in this PR -->
Import `LM` from `dspy` and not `dsp`.

## Checklist
- ~[ ] Tests have been extended to cover changes in functionality~
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
