### PR TITLE
Introduce `Engine` class to abstract away specialized engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ Here's a simple classification example using [`outlines`](https://github.com/dot
 ```python
 import outlines
 
-from sieves import Pipeline, engines, tasks, Doc
+from sieves import Pipeline, Engine, tasks, Doc
 
 # 1. Define documents by text or URI.
 docs = [Doc(text="Special relativity applies to all physical phenomena in the absence of gravity.")]
 
 # 2. Create engine responsible for generating structured output.
 model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
-engine = engines.Outlines(model=outlines.models.transformers(model_name))
+engine = Engine(model=outlines.models.transformers(model_name))
 
 # 3. Create pipeline with tasks.
 pipe = Pipeline(
@@ -119,14 +119,14 @@ import gliner.multitask
 import chonkie
 import tokenizers
 
-from sieves import Pipeline, engines, tasks, Doc
+from sieves import Pipeline, Engine, tasks, Doc
 
 # 1. Define documents by text or URI.
 docs = [Doc(uri="https://arxiv.org/pdf/2408.09869")]
 
 # 2. Create engine responsible for generating structured output.
 model_name = 'knowledgator/gliner-multitask-v1.0'
-engine = engines.GliX(model=gliner.GLiNER.from_pretrained(model_name))
+engine = Engine(model=gliner.GLiNER.from_pretrained(model_name))
 
 # 3. Create chunker object.
 chunker = chonkie.TokenChunker(tokenizers.Tokenizer.from_pretrained(model_name))

--- a/docs/engines/base_engine.md
+++ b/docs/engines/base_engine.md
@@ -1,0 +1,3 @@
+# Base Engine
+
+::: sieves.engines.core

--- a/docs/engines/base_engine.md
+++ b/docs/engines/base_engine.md
@@ -1,3 +1,3 @@
-# Base Engine
+# Internal Engine
 
 ::: sieves.engines.core

--- a/docs/engines/engine.md
+++ b/docs/engines/engine.md
@@ -1,3 +1,3 @@
 # Engine
 
-::: sieves.engines.core
+::: sieves.engines.wrapper

--- a/docs/guides/custom_tasks.md
+++ b/docs/guides/custom_tasks.md
@@ -242,11 +242,12 @@ And that's it! Our sentiment analysis task is finished.
 We can now use our sentiment analysis task like every built-in task:
 
 ```python
-from sieves import Doc, Pipeline, engines
+from sieves import Doc, Pipeline, Engine
+import outlines
 from .sentiment_analysis_task import SentimentAnalysis
 
 model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
-engine = engines.outlines_.Outlines(model=outlines.models.transformers(model_name))
+engine = Engine(model=outlines.models.transformers(model_name))
             
 docs = [Doc(text="I'm feeling happy today."), Doc(text="I was sad yesterday.")]
 pipe = Pipeline([SentimentAnalysis(engine=engine)])

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -17,15 +17,13 @@ Here's a simple example that performs text classification:
 
 ```python
 import outlines
-from sieves import Pipeline, engines, tasks, Doc
+from sieves import Pipeline, Engine, tasks, Doc
 
 # Create a document
 doc = Doc(text="Special relativity applies to all physical phenomena in the absence of gravity.")
 
 # Initialize the engine (using a small but capable model)
-engine = engines.outlines_.Outlines(
-    model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct")
-)
+engine = Engine(model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct"))
 
 # Create and run the pipeline
 pipeline = Pipeline([tasks.predictive.Classification(labels=["science", "politics"], engine=engine)])
@@ -40,6 +38,8 @@ for doc in pipeline([doc]):
 Documents can be created in several ways:
 
 ```python
+from sieves import Docs
+
 # From text
 doc = Doc(text="Your text here")
 
@@ -66,7 +66,7 @@ import outlines
 import chonkie
 import tokenizers
 import pydantic
-from sieves import Pipeline, engines, tasks, Doc
+from sieves import Pipeline, Engine, tasks, Doc
 
 # Create a tokenizer for chunking
 tokenizer = tokenizers.Tokenizer.from_pretrained("bert-base-uncased")
@@ -77,7 +77,7 @@ chunker = tasks.preprocessing.Chonkie(
 )
 
 # Initialize an engine for information extraction
-engine = engines.outlines_.Outlines(model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct"))
+engine = Engine(model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct"))
 
 # Define the structure of information you want to extract
 class PersonInfo(pydantic.BaseModel):
@@ -108,7 +108,7 @@ for result in results:
 
 ## Supported Engines
 
-`sieves` supports multiple engines for structured generation:
+`sieves` supports multiple libraries for structured generation:
 
 - [`outlines`](https://github.com/outlines-dev/outlines)
 - [`dspy`](https://github.com/stanfordnlp/dspy)
@@ -118,5 +118,4 @@ for result in results:
 - [`transformers`](https://github.com/huggingface/transformers)
 - [`ollama`](https://github.com/ollama/ollama)
 
-Each engine has a different set of supported models, pros and cons. Choose the engine that best fits your use case and 
-model requirements.
+You can pass in models from either of these structured generation libraries into `Engine`.   

--- a/docs/guides/serialization.md
+++ b/docs/guides/serialization.md
@@ -12,12 +12,12 @@ Here's a simple example of saving and loading a classification pipeline:
 
 ```python
 import outlines
-from sieves import Pipeline, engines, tasks, Doc
+from sieves import Pipeline, Engine, tasks, Doc
 from pathlib import Path
 
 # Create a basic classification pipeline
 model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
-engine = engines.outlines_.Outlines(model=outlines.models.transformers(model_name))
+engine = Engine(model=outlines.models.transformers(model_name))
 classifier = tasks.predictive.Classification(
     labels=["science", "politics"], 
     engine=engine
@@ -49,7 +49,7 @@ import chonkie
 import tokenizers
 import outlines
 import pydantic
-from sieves import Pipeline, engines, tasks
+from sieves import Pipeline, Engine, tasks
 
 # Create a tokenizer for chunking
 tokenizer = tokenizers.Tokenizer.from_pretrained("bert-base-uncased")
@@ -58,7 +58,7 @@ chunker = tasks.preprocessing.Chonkie(
 )
 
 # Create an information extraction task
-engine = engines.outlines_.Outlines(model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct"))
+engine = Engine(model=outlines.models.transformers("HuggingFaceTB/SmolLM-135M-Instruct"))
 class PersonInfo(pydantic.BaseModel):
     name: str
     age: int | None = None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
 
     - Engines:
         - engines/engine.md
+        - engines/base_engine.md
         - All Engines:
             - engines/dspy.md
             - engines/gliner.md

--- a/sieves/__init__.py
+++ b/sieves/__init__.py
@@ -1,6 +1,7 @@
 import sieves.tasks as tasks
 from sieves.data import Doc
 
+from .engines import Engine
 from .pipeline import Pipeline
 
-__all__ = ["Doc", "tasks", "Pipeline"]
+__all__ = ["Doc", "Engine", "tasks", "Pipeline"]

--- a/sieves/engines/__init__.py
+++ b/sieves/engines/__init__.py
@@ -1,68 +1,27 @@
 from __future__ import annotations
 
-import enum
-
 from . import dspy_, glix_, huggingface_, instructor_, langchain_, ollama_, outlines_
-from .core import Engine, EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
+from .core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult, InternalEngine
 from .dspy_ import DSPy
-from .glix_ import GliX
-from .huggingface_ import HuggingFace
-from .instructor_ import Instructor
-from .langchain_ import LangChain
-from .ollama_ import Ollama
-from .outlines_ import Outlines
-
-
-class EngineType(enum.Enum):
-    dspy = dspy_.DSPy
-    glix = glix_.GliX
-    huggingface = huggingface_.HuggingFace
-    instructor = instructor_.Instructor
-    langchain = langchain_.LangChain
-    ollama = ollama_.Ollama
-    outlines = outlines_.Outlines
-
-    @classmethod
-    def all(cls) -> tuple[EngineType, ...]:
-        """Returns all available engine types.
-        :return tuple[EngineType, ...]: All available engine types.
-        """
-        return tuple(engine_type for engine_type in EngineType)
-
-    @classmethod
-    def get_engine_type(
-        cls, engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode]
-    ) -> EngineType:
-        """Returns engine type for specified engine.
-        :param engine: Engine to get type for.
-        :return EngineType: Engine type for self._engine.
-        :raises: ValueError if engine class not found in EngineType.
-        """
-        for et in EngineType:
-            if isinstance(engine, et.value):
-                return et
-        raise ValueError(f"Engine class {engine.__class__.__name__} not found in EngineType.")
-
+from .engine_type import EngineType
+from .wrapper import Engine
 
 __all__ = [
     "dspy_",
     "DSPy",
+    "wrapper",
     "Engine",
+    "EngineInferenceMode",
+    "EngineModel",
+    "EnginePromptSignature",
     "EngineType",
+    "EngineResult",
+    "InternalEngine",
     "glix_",
-    "GliX",
     "langchain_",
-    "LangChain",
     "huggingface_",
-    "HuggingFace",
     "instructor_",
     "Instructor",
-    "EngineResult",
-    "EngineModel",
     "ollama_",
-    "Ollama",
     "outlines_",
-    "Outlines",
-    "EngineInferenceMode",
-    "EnginePromptSignature",
 ]

--- a/sieves/engines/engine_type.py
+++ b/sieves/engines/engine_type.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import enum
+
+from . import dspy_, glix_, huggingface_, instructor_, langchain_, ollama_, outlines_
+from .core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult, InternalEngine
+
+
+class EngineType(enum.Enum):
+    dspy = dspy_.DSPy
+    glix = glix_.GliX
+    huggingface = huggingface_.HuggingFace
+    instructor = instructor_.Instructor
+    langchain = langchain_.LangChain
+    ollama = ollama_.Ollama
+    outlines = outlines_.Outlines
+
+    @classmethod
+    def all(cls) -> tuple[EngineType, ...]:
+        """Returns all available engine types.
+        :return tuple[EngineType, ...]: All available engine types.
+        """
+        return tuple(engine_type for engine_type in EngineType)
+
+    @classmethod
+    def get_engine_type(
+        cls, engine: InternalEngine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode]
+    ) -> EngineType:
+        """Returns engine type for specified engine.
+        :param engine: Engine to get type for.
+        :return EngineType: Engine type for self._engine.
+        :raises: ValueError if engine class not found in EngineType.
+        """
+        for et in EngineType:
+            if isinstance(engine, et.value):
+                return et
+        raise ValueError(f"Engine class {engine.__class__.__name__} not found in EngineType.")

--- a/sieves/engines/glix_.py
+++ b/sieves/engines/glix_.py
@@ -9,7 +9,7 @@ import gliner.multitask.base
 import jinja2
 import pydantic
 
-from sieves.engines.core import Engine, Executable
+from sieves.engines.core import Executable, InternalEngine
 
 PromptSignature: TypeAlias = list[str]
 Model: TypeAlias = gliner.model.GLiNER
@@ -27,14 +27,14 @@ class InferenceMode(enum.Enum):
     relation_extraction = gliner.multitask.GLiNERRelationExtractor
 
 
-class GliX(Engine[PromptSignature, Result, Model, InferenceMode]):
+class GliX(InternalEngine[PromptSignature, Result, Model, InferenceMode]):
     def __init__(
         self,
         model: Model,
-        init_kwargs: dict[str, Any] | None = None,
-        inference_kwargs: dict[str, Any] | None = None,
-        strict_mode: bool = False,
-        batch_size: int = -1,
+        init_kwargs: dict[str, Any] | None,
+        inference_kwargs: dict[str, Any] | None,
+        strict_mode: bool,
+        batch_size: int,
     ):
         super().__init__(model, init_kwargs, inference_kwargs, strict_mode, batch_size)
         self._model_wrappers: dict[InferenceMode, gliner.multitask.base.GLiNERBasePipeline] = {}

--- a/sieves/engines/huggingface_.py
+++ b/sieves/engines/huggingface_.py
@@ -8,7 +8,7 @@ import jinja2
 import pydantic
 import transformers
 
-from sieves.engines.core import Engine, Executable
+from sieves.engines.core import Executable, InternalEngine
 
 PromptSignature: TypeAlias = list[str]
 Model: TypeAlias = transformers.Pipeline
@@ -21,7 +21,7 @@ class InferenceMode(enum.Enum):
     zeroshot_cls = 0
 
 
-class HuggingFace(Engine[PromptSignature, Result, Model, InferenceMode]):
+class HuggingFace(InternalEngine[PromptSignature, Result, Model, InferenceMode]):
     @property
     def inference_modes(self) -> type[InferenceMode]:
         return InferenceMode

--- a/sieves/engines/wrapper.py
+++ b/sieves/engines/wrapper.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, TypeAlias
+
+import pydantic
+
+from sieves.engines import InternalEngine, dspy_, glix_, huggingface_, instructor_, langchain_, ollama_, outlines_
+from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult, Executable
+from sieves.engines.engine_type import EngineType
+
+PromptSignature: TypeAlias = (
+    dspy_.PromptSignature
+    | glix_.PromptSignature
+    | huggingface_.PromptSignature
+    | instructor_.PromptSignature
+    | langchain_.PromptSignature
+    | ollama_.PromptSignature
+    | outlines_.PromptSignature
+)
+Model: TypeAlias = (
+    dspy_.Model
+    | glix_.Model
+    | huggingface_.Model
+    | instructor_.Model
+    | langchain_.Model
+    | ollama_.Model
+    | outlines_.Model
+)
+Result: TypeAlias = (
+    dspy_.Result
+    | glix_.Result
+    | huggingface_.Result
+    | instructor_.Result
+    | langchain_.Result
+    | ollama_.Result
+    | outlines_.Result
+)
+InferenceMode: TypeAlias = (
+    dspy_.InferenceMode
+    | glix_.InferenceMode
+    | huggingface_.InferenceMode
+    | instructor_.InferenceMode
+    | langchain_.InferenceMode
+    | ollama_.InferenceMode
+    | outlines_.InferenceMode
+)
+
+
+class Engine(InternalEngine[PromptSignature, Result, Model, InferenceMode]):
+    def __init__(
+        self,
+        model: Model,
+        init_kwargs: dict[str, Any] | None = None,
+        inference_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+        strict_mode: bool = False,
+        batch_size: int = -1,
+    ):
+        """
+        :param model: Model to run.
+        :param init_kwargs: Optional kwargs to supply to engine executable at init time.
+        :param inference_kwargs: Optional kwargs to supply to engine executable at inference time.
+        :param config_kwargs: Used only if supplied model is a DSPy model object, ignored otherwise. Optional kwargs
+            supplied to dspy.configure().
+        :param strict_mode: If True, exception is raised if prompt response can't be parsed correctly.
+        :param batch_size: Batch size in processing prompts. -1 will batch all documents in one go. Not all engines
+            support batching.
+        """
+        super().__init__(model, init_kwargs, inference_kwargs, strict_mode, batch_size)
+        self._config_kwargs = config_kwargs
+        self._engine: InternalEngine[PromptSignature, Result, Model, InferenceMode] = self._init_engine()
+
+    def _init_engine(self) -> InternalEngine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode]:
+        """Initializes internal engine object.
+        :return Engine: Engine.
+        :raises: ValueError if model type isn't supported.
+        """
+        model_type = type(self._model)
+        module_engine_map = {
+            dspy_: dspy_.DSPy,
+            glix_: glix_.GliX,
+            huggingface_: huggingface_.HuggingFace,
+            instructor_: instructor_.Instructor,
+            langchain_: langchain_.LangChain,
+            ollama_: ollama_.Ollama,
+            outlines_: outlines_.Outlines,
+        }
+
+        for module, engine_type in module_engine_map.items():
+            try:
+                module_model_types = module.Model.__args__
+            except AttributeError:
+                module_model_types = (module.Model,)
+
+            if any(issubclass(model_type, module_model_type) for module_model_type in module_model_types):
+                internal_engine = engine_type(
+                    model=self._model,
+                    init_kwargs=self._init_kwargs,
+                    inference_kwargs=self._inference_kwargs,
+                    strict_mode=self._strict_mode,
+                    batch_size=self._batch_size,
+                    **{"config_kwargs": self._config_kwargs} if module == dspy_ else {},
+                )
+                assert isinstance(internal_engine, InternalEngine)
+                return internal_engine
+
+        raise ValueError(
+            f"Model type {self.model.__class__} is not supported. Please check the documentation and ensure you're "
+            f"providing a supported model type."
+        )
+
+    @property
+    def supports_few_shotting(self) -> bool:
+        return self._engine.supports_few_shotting
+
+    @property
+    def inference_modes(self) -> type[InferenceMode]:
+        return self._engine.inference_modes
+
+    def build_executable(
+        self,
+        inference_mode: InferenceMode,
+        prompt_template: str | None,
+        prompt_signature: type[PromptSignature] | PromptSignature,
+        fewshot_examples: Iterable[pydantic.BaseModel] = (),
+    ) -> Executable[Result | None]:
+        return self._engine.build_executable(
+            inference_mode=inference_mode,
+            prompt_template=prompt_template,
+            prompt_signature=prompt_signature,
+            fewshot_examples=fewshot_examples,
+        )
+
+    def get_engine_type(self) -> EngineType:
+        """Returns engine type for specified engine.
+        :return EngineType: Engine type for self._engine.
+        :raises: ValueError if engine class not found in EngineType.
+        """
+        return EngineType.get_engine_type(self._engine)

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -8,7 +8,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_, glix_, huggingface_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.bridges import GliXBridge
 from sieves.tasks.predictive.classification.bridges import (
@@ -50,7 +49,7 @@ class Classification(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBrid
     def __init__(
         self,
         labels: list[str],
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None = None,
         show_progress: bool = True,
         include_meta: bool = True,

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import enum
 from collections.abc import Iterable
 from typing import Any, Generic
 
@@ -9,14 +8,7 @@ import datasets
 import pydantic
 
 from sieves.data import Doc
-from sieves.engines import (
-    Engine,
-    EngineInferenceMode,
-    EngineModel,
-    EnginePromptSignature,
-    EngineResult,
-    EngineType,
-)
+from sieves.engines import Engine, EngineInferenceMode, EngineType  # noqa: F401
 from sieves.serialization import Config, Serializable
 from sieves.tasks.core import Task
 from sieves.tasks.predictive.bridges import TaskBridge, TaskPromptSignature, TaskResult
@@ -29,7 +21,7 @@ class PredictiveTask(
 ):
     def __init__(
         self,
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None,
         show_progress: bool,
         include_meta: bool,
@@ -55,7 +47,7 @@ class PredictiveTask(
         self._overwrite = overwrite
         self._custom_prompt_template = prompt_template
         self._custom_prompt_signature_desc = prompt_signature_desc
-        self._bridge = self._init_bridge(EngineType.get_engine_type(self._engine))
+        self._bridge = self._init_bridge(self._engine.get_engine_type())
         self._fewshot_examples = fewshot_examples
 
         self._validate_fewshot_examples()
@@ -116,7 +108,6 @@ class PredictiveTask(
         signature = self._bridge.prompt_signature
 
         # 2. Build executable.
-        assert isinstance(self._bridge.inference_mode, enum.Enum)
         executable = self._engine.build_executable(
             inference_mode=self._bridge.inference_mode,
             prompt_template=self.prompt_template,

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -9,7 +9,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_, glix_, ollama_, outlines_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.core import PredictiveTask
 from sieves.tasks.predictive.information_extraction.bridges import (
@@ -42,7 +41,7 @@ class InformationExtraction(PredictiveTask[_TaskPromptSignature, _TaskResult, _T
     def __init__(
         self,
         entity_type: type[pydantic.BaseModel],
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None = None,
         show_progress: bool = True,
         include_meta: bool = True,

--- a/sieves/tasks/predictive/pii_masking/core.py
+++ b/sieves/tasks/predictive/pii_masking/core.py
@@ -6,15 +6,7 @@ import datasets
 import pydantic
 
 from sieves.data.doc import Doc
-from sieves.engines import (
-    Engine,
-    EngineInferenceMode,
-    EngineModel,
-    EnginePromptSignature,
-    EngineResult,
-    EngineType,
-    dspy_,
-)
+from sieves.engines import Engine, EngineType, dspy_
 from sieves.serialization import Config
 from sieves.tasks.predictive.core import PredictiveTask
 from sieves.tasks.predictive.pii_masking.bridges import (
@@ -53,7 +45,7 @@ class PIIMasking(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge])
 
     def __init__(
         self,
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         pii_types: list[str] | None = None,
         mask_placeholder: str = "[MASKED]",
         task_id: str | None = None,

--- a/sieves/tasks/predictive/question_answering/core.py
+++ b/sieves/tasks/predictive/question_answering/core.py
@@ -8,7 +8,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_, glix_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.bridges import GliXBridge
 from sieves.tasks.predictive.core import PredictiveTask
@@ -36,7 +35,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
     def __init__(
         self,
         questions: list[str],
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None = None,
         show_progress: bool = True,
         include_meta: bool = True,

--- a/sieves/tasks/predictive/sentiment_analysis/core.py
+++ b/sieves/tasks/predictive/sentiment_analysis/core.py
@@ -8,7 +8,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.core import PredictiveTask
 from sieves.tasks.predictive.sentiment_analysis.bridges import (
@@ -48,7 +47,7 @@ class FewshotExample(pydantic.BaseModel):
 class SentimentAnalysis(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]):
     def __init__(
         self,
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         aspects: tuple[str, ...] = tuple(),
         task_id: str | None = None,
         show_progress: bool = True,

--- a/sieves/tasks/predictive/summarization/core.py
+++ b/sieves/tasks/predictive/summarization/core.py
@@ -8,7 +8,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_, glix_, ollama_, outlines_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.bridges import GliXBridge
 from sieves.tasks.predictive.core import PredictiveTask
@@ -42,7 +41,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
     def __init__(
         self,
         n_words: int,
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None = None,
         show_progress: bool = True,
         include_meta: bool = True,

--- a/sieves/tasks/predictive/translation/core.py
+++ b/sieves/tasks/predictive/translation/core.py
@@ -8,7 +8,6 @@ import pydantic
 
 from sieves.data import Doc
 from sieves.engines import Engine, EngineType, dspy_, ollama_, outlines_
-from sieves.engines.core import EngineInferenceMode, EngineModel, EnginePromptSignature, EngineResult
 from sieves.serialization import Config
 from sieves.tasks.predictive.core import PredictiveTask
 from sieves.tasks.predictive.translation.bridges import (
@@ -36,7 +35,7 @@ class Translation(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]
     def __init__(
         self,
         to: str,
-        engine: Engine[EnginePromptSignature, EngineResult, EngineModel, EngineInferenceMode],
+        engine: Engine,
         task_id: str | None = None,
         show_progress: bool = True,
         include_meta: bool = True,

--- a/sieves/tests/tasks/test_classification.py
+++ b/sieves/tests/tasks/test_classification.py
@@ -9,7 +9,7 @@ from sieves.tasks import PredictiveTask
 from sieves.tasks.predictive import classification
 
 
-def _run(engine: engines.Engine, docs: list[Doc], fewshot: bool) -> None:
+def _run(engine: engines.InternalEngine, docs: list[Doc], fewshot: bool) -> None:
     assert issubclass(engine.inference_modes, enum.Enum)
     fewshot_examples = [
         classification.FewshotExample(
@@ -92,7 +92,7 @@ def test_serialization(dummy_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.huggingface_.HuggingFace",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {

--- a/sieves/tests/tasks/test_information_extraction.py
+++ b/sieves/tests/tasks/test_information_extraction.py
@@ -84,7 +84,7 @@ def test_serialization(information_extraction_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.ollama_.Ollama",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "sieves.engines.ollama_.Model"},

--- a/sieves/tests/tasks/test_misc.py
+++ b/sieves/tests/tasks/test_misc.py
@@ -10,13 +10,13 @@ import dspy
 import pydantic
 import pytest
 
-from sieves import Doc, Pipeline, engines, tasks
+from sieves import Doc, Engine, Pipeline, engines, tasks
 from sieves.tasks.utils import PydanticToHFDatasets
 
 
 def test_custom_prompt_template():
     prompt_template = "This is a different prompt template."
-    engine = engines.dspy_.DSPy(model=dspy.LM("claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY"]))
+    engine = Engine(model=dspy.LM("claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY"]))
     task = tasks.predictive.Classification(
         task_id="classifier",
         labels=["science", "politics"],
@@ -28,7 +28,7 @@ def test_custom_prompt_template():
 
 def test_custom_prompt_signature_desc():
     prompt_sig_desc = "This is a different prompt signature description."
-    engine = engines.dspy_.DSPy(model=dspy.LM("claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY"]))
+    engine = Engine(model=dspy.LM("claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY"]))
     task = tasks.predictive.Classification(
         task_id="classifier",
         labels=["science", "politics"],

--- a/sieves/tests/tasks/test_pii_masking.py
+++ b/sieves/tests/tasks/test_pii_masking.py
@@ -72,7 +72,7 @@ def test_serialization(pii_masking_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.ollama_.Ollama",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "sieves.engines.ollama_.Model"},

--- a/sieves/tests/tasks/test_question_answering.py
+++ b/sieves/tests/tasks/test_question_answering.py
@@ -118,7 +118,7 @@ def test_serialization(qa_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.outlines_.Outlines",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "outlines.models.transformers.Transformers"},

--- a/sieves/tests/tasks/test_sentiment_analysis.py
+++ b/sieves/tests/tasks/test_sentiment_analysis.py
@@ -91,7 +91,7 @@ def test_serialization(dummy_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.outlines_.Outlines",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "outlines.models.transformers.Transformers"},

--- a/sieves/tests/tasks/test_summarization.py
+++ b/sieves/tests/tasks/test_summarization.py
@@ -84,7 +84,7 @@ def test_serialization(summarization_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.dspy_.DSPy",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "dspy.clients.lm.LM"},

--- a/sieves/tests/tasks/test_translation.py
+++ b/sieves/tests/tasks/test_translation.py
@@ -72,7 +72,7 @@ def test_serialization(translation_docs, batch_engine) -> None:
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.dspy_.DSPy",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "dspy.clients.lm.LM"},

--- a/sieves/tests/test_serialization.py
+++ b/sieves/tests/test_serialization.py
@@ -51,7 +51,7 @@ def test_serialization_pipeline(dummy_docs, batch_engine, tokenizer):
                     "engine": {
                         "is_placeholder": False,
                         "value": {
-                            "cls_name": "sieves.engines.dspy_.DSPy",
+                            "cls_name": "sieves.engines.wrapper.Engine",
                             "inference_kwargs": {"is_placeholder": False, "value": {}},
                             "init_kwargs": {"is_placeholder": False, "value": {}},
                             "model": {"is_placeholder": True, "value": "dspy.clients.lm.LM"},


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Introduces `Engine` class to abstract away specialized engines. API doesn't require instantiating specialized engines (DSPy engine, HF engine, ...) anymore, just the `Engine` class. `Engine` is a wrapper, under the hood specialized engines classes are used.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
Resolves #102.

## Changes Made
<!-- List key changes in this PR -->
- Introduces `Engine` class (breaking change)

## Checklist
- [x] Tests have been extended to cover changes in functionality
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
