### PR TITLE
Add ability to generate docs from datasets

### DIFF
--- a/sieves/data/doc.py
+++ b/sieves/data/doc.py
@@ -4,8 +4,8 @@ import dataclasses
 from pathlib import Path
 from typing import Any
 
-from PIL import ImageChops
-from PIL.Image import Image
+from datasets import Dataset
+from PIL import Image, ImageChops
 
 
 @dataclasses.dataclass
@@ -18,14 +18,14 @@ class Doc:
     text: str | None = None
     chunks: list[str] | None = None
     id: str | None = None
-    images: list[Image] | None = None
+    images: list[Image.Image] | None = None
 
     def __post_init__(self) -> None:
         if self.chunks is None and self.text is not None:
             self.chunks = [self.text]
 
     @staticmethod
-    def _are_images_equal(im1: Image, im2: Image) -> bool:
+    def _are_images_equal(im1: Image.Image | None, im2: Image.Image | None) -> bool:
         """Check if two images are equal using PIL Image Channel operations.
         :param im1: First PIL image to compare.
         :param im2: Second PIL image to compare.
@@ -41,7 +41,7 @@ class Doc:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Doc):
-            raise NotImplementedError
+            return NotImplemented
         # Check if images are equal
         images_equal_check = False
         if self.images is None and other.images is None:
@@ -63,3 +63,27 @@ class Doc:
             and self.results == other.results
             and images_equal_check
         )
+
+    @classmethod
+    def from_hf_dataset(cls, dataset: Dataset, text_column: str = "text") -> list[Doc]:
+        """Generate list of docs from Hugging Face dataset.
+
+        :param dataset: Dataset to generate Docs from. Must have a column with a name that equals `text_column`.
+            Other columns are ignored.
+        :param text_column: Column to pull text from when creating Doc instances.
+        :return: List of Doc instances, each representing one row in the dataset.
+        :raises ValueError: If `text_column` is not present in the dataset features.
+        """
+        if text_column not in dataset.column_names:
+            raise ValueError(
+                f"Specified text_column '{text_column}' not found in dataset columns: {dataset.column_names}."
+            )
+
+        docs: list[Doc] = []
+        for row in dataset:
+            # Assuming row is a dict-like object, typical for Hugging Face datasets.
+            text_content = row.get(text_column)
+            if isinstance(text_content, str):
+                docs.append(cls(text=text_content))
+
+        return docs

--- a/sieves/data/doc.py
+++ b/sieves/data/doc.py
@@ -43,7 +43,8 @@ class Doc:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Doc):
-            return NotImplemented
+            raise NotImplementedError
+
         # Check if images are equal
         images_equal_check = False
         if self.images is None and other.images is None:

--- a/sieves/data/doc.py
+++ b/sieves/data/doc.py
@@ -42,6 +42,10 @@ class Doc:
         return ImageChops.difference(im1, im2).getbbox() is None
 
     def __eq__(self, other: object) -> bool:
+        """Compares two `Doc` instances.
+        :return: True if `self` is equal to `other`.
+        :raises: NotImplementedError if `other` isn't of type `Doc`.
+        """
         if not isinstance(other, Doc):
             raise NotImplementedError
 

--- a/sieves/tests/test_doc.py
+++ b/sieves/tests/test_doc.py
@@ -18,56 +18,48 @@ def test_images() -> dict[str, Image.Image]:
     }
 
 
-@pytest.mark.image_comparison
 def test_identical_images(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_red_100_2"]])
     assert doc1 == doc2
 
 
-@pytest.mark.image_comparison
 def test_different_images(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_blue_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison
 def test_none_images() -> None:
     doc1 = Doc(images=None)
     doc2 = Doc(images=None)
     assert doc1 == doc2
 
 
-@pytest.mark.image_comparison
 def test_one_none_image(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=None)
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison
 def test_different_image_counts(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"], test_images["rgb_red_100_2"]])
     doc2 = Doc(images=[test_images["rgb_red_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison
 def test_different_image_sizes(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_red_200"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison
 def test_different_image_modes(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["l_gray_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison
 def test_doc_comparison_type_error() -> None:
     doc = Doc(images=None)
     with pytest.raises(NotImplementedError):

--- a/sieves/tests/test_doc.py
+++ b/sieves/tests/test_doc.py
@@ -1,11 +1,12 @@
 # mypy: ignore-errors
 import pytest
+from datasets import Dataset
 from PIL import Image
 
 from sieves import Doc
 
 
-@pytest.fixture  # type: ignore[misc]
+@pytest.fixture
 def test_images() -> dict[str, Image.Image]:
     return {
         "rgb_red_100": Image.new("RGB", (100, 100), color="red"),
@@ -16,57 +17,90 @@ def test_images() -> dict[str, Image.Image]:
     }
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_identical_images(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_red_100_2"]])
     assert doc1 == doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_different_images(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_blue_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_none_images() -> None:
     doc1 = Doc(images=None)
     doc2 = Doc(images=None)
     assert doc1 == doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_one_none_image(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=None)
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_different_image_counts(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"], test_images["rgb_red_100_2"]])
     doc2 = Doc(images=[test_images["rgb_red_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_different_image_sizes(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["rgb_red_200"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_different_image_modes(test_images: dict[str, Image.Image]) -> None:
     doc1 = Doc(images=[test_images["rgb_red_100"]])
     doc2 = Doc(images=[test_images["l_gray_100"]])
     assert doc1 != doc2
 
 
-@pytest.mark.image_comparison  # type: ignore[misc]
+@pytest.mark.image_comparison
 def test_doc_comparison_type_error() -> None:
     doc = Doc(images=None)
     with pytest.raises(NotImplementedError):
         doc == 42
+
+
+def test_docs_from_hf_dataset() -> None:
+    """Tests generation of Docs instance from HF dataset."""
+    hf_dataset = Dataset.from_dict(
+        {"text": ["This is the first document.", "This is the second document."], "label": [0, 1]}
+    )
+    docs = Doc.from_hf_dataset(hf_dataset)
+
+    # 3. Add assertions
+    assert len(docs) == 2
+    assert docs[0].text == "This is the first document."
+    assert docs[0].chunks == ["This is the first document."]  # Check post_init
+    assert docs[0].id is None
+    assert docs[0].uri is None
+    assert docs[0].images is None
+    assert docs[0].meta == {}
+    assert docs[0].results == {}
+
+    assert docs[1].text == "This is the second document."
+    assert docs[1].chunks == ["This is the second document."]  # Check post_init
+
+    # Test with a different text column name
+    data_alt_col = {"content": ["Doc A", "Doc B"], "id": ["a", "b"]}
+    hf_dataset_alt_col = Dataset.from_dict(data_alt_col)
+    docs_alt = Doc.from_hf_dataset(hf_dataset_alt_col, text_column="content")
+    assert len(docs_alt) == 2
+    assert docs_alt[0].text == "Doc A"
+    assert docs_alt[1].text == "Doc B"
+
+    # Test ValueError for missing column
+    with pytest.raises(ValueError, match="Specified text_column 'wrong_column' not found"):
+        Doc.from_hf_dataset(hf_dataset, text_column="wrong_column")


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Add `Doc.from_hf_datasets()`, which generates a list of `Doc` instances from a HF `datasets.Dataset`.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
Resolves #126.

## Changes Made
<!-- List key changes in this PR -->
- Add HF dataset-to-`Doc` factory method

## Checklist
- [x] Tests have been extended to cover changes in functionality
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
