### PR TITLE
Classification: add single-label mode

### DIFF
--- a/sieves/engines/langchain_.py
+++ b/sieves/engines/langchain_.py
@@ -47,6 +47,7 @@ class LangChain(PydanticEngine[PromptSignature, Result, Model, InferenceMode]):
                     def generate(prompts: list[str]) -> Iterable[Result]:
                         try:
                             yield from asyncio.run(model.abatch(prompts, **self._inference_kwargs))
+
                         except pydantic.ValidationError as ex:
                             raise pydantic.ValidationError(
                                 f"Encountered problem in parsing {cls_name} output. Double-check your prompts and "

--- a/sieves/tasks/predictive/bridges.py
+++ b/sieves/tasks/predictive/bridges.py
@@ -111,6 +111,7 @@ class GliXBridge(Bridge[list[str], glix_.Result, glix_.InferenceMode]):
         prompt_signature: tuple[str, ...] | list[str],
         inference_mode: glix_.InferenceMode,
         label_whitelist: tuple[str, ...] | None = None,
+        only_keep_best: bool = False,
     ):
         """
         Initializes GliX bridge.
@@ -120,6 +121,7 @@ class GliXBridge(Bridge[list[str], glix_.Result, glix_.InferenceMode]):
         :param prompt_signature: Prompt signature.
         :param inference_mode: Inference mode.
         :param label_whitelist: Labels to record predictions for. If None, predictions for all labels are recorded.
+        :param only_keep_best: Whether to only return the result with the highest score.
         """
         super().__init__(
             task_id=task_id,
@@ -134,6 +136,7 @@ class GliXBridge(Bridge[list[str], glix_.Result, glix_.InferenceMode]):
             glix_.InferenceMode.classification,
             glix_.InferenceMode.question_answering,
         )
+        self._only_keep_best = only_keep_best
         self._pred_attr: str | None = None
 
     @property
@@ -159,6 +162,9 @@ class GliXBridge(Bridge[list[str], glix_.Result, glix_.InferenceMode]):
                 for res in sorted(result, key=lambda x: x["score"], reverse=True):
                     assert isinstance(res, dict)
                     doc.results[self._task_id].append((res[self._pred_attr], res["score"]))
+
+                if self._only_keep_best:
+                    doc.results[self._task_id] = doc.results[self._task_id][0]
             else:
                 doc.results[self._task_id] = result
         return docs

--- a/sieves/tasks/predictive/classification/__init__.py
+++ b/sieves/tasks/predictive/classification/__init__.py
@@ -1,5 +1,5 @@
 """Classification task."""
 
-from .core import Classification, FewshotExample
+from .core import Classification, FewshotExampleMultiLabel, FewshotExampleSingleLabel
 
-__all__ = ["Classification", "FewshotExample"]
+__all__ = ["Classification", "FewshotExampleMultiLabel", "FewshotExampleSingleLabel"]

--- a/sieves/tasks/predictive/classification/bridges.py
+++ b/sieves/tasks/predictive/classification/bridges.py
@@ -481,6 +481,9 @@ class OutlinesClassification(PydanticBasedClassification[outlines_.InferenceMode
         """
 
     def integrate(self, results: Iterable[pydantic.BaseModel | str], docs: Iterable[Doc]) -> Iterable[Doc]:
+        if self._multi_label:
+            return super().integrate(results, docs)
+
         for doc, result in zip(docs, results):
             doc.results[self._task_id] = result
         return docs
@@ -491,12 +494,13 @@ class OutlinesClassification(PydanticBasedClassification[outlines_.InferenceMode
         if self._multi_label:
             yield from super().consolidate(results, docs_offsets)
 
-        # Determine label scores for chunks per document.
-        results = list(results)
-        for doc_offset in docs_offsets:
-            doc_results = results[doc_offset[0] : doc_offset[1]]
-            label_counts = Counter(doc_results)
-            yield label_counts.most_common()[0][0]
+        else:
+            # Determine label scores for chunks per document.
+            results = list(results)
+            for doc_offset in docs_offsets:
+                doc_results = results[doc_offset[0] : doc_offset[1]]
+                label_counts = Counter(doc_results)
+                yield label_counts.most_common()[0][0]
 
     @property
     def inference_mode(self) -> outlines_.InferenceMode:

--- a/sieves/tests/conftest.py
+++ b/sieves/tests/conftest.py
@@ -37,7 +37,10 @@ def _make_engine(engine_type: engines.EngineType, batch_size: int) -> Engine:
 
         case engines.EngineType.langchain:
             model = init_chat_model(
-                model="claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY"], model_provider="anthropic"
+                model="claude-3-haiku-20240307",
+                api_key=os.environ["ANTHROPIC_API_KEY"],
+                model_provider="anthropic",
+                temperature=0,
             )
 
         case engines.EngineType.instructor:
@@ -81,6 +84,20 @@ def engine(request) -> engines.Engine:
 @pytest.fixture(scope="session")
 def dummy_docs() -> list[Doc]:
     return [Doc(text="This is about politics stuff. " * 10), Doc(text="This is about science stuff. " * 10)]
+
+
+@pytest.fixture(scope="session")
+def classification_docs() -> list[Doc]:
+    return [
+        Doc(
+            text="A new law has been passed. The opposition doesn't support it, but parliament has voted on it. This "
+            "is about politics - parliament, laws, parties, politicians."
+        ),
+        Doc(
+            text="Scientists report that plasma is a state of matter. They published an academic paper. This is about "
+            "science - scientists, papers, experiments, laws of nature."
+        ),
+    ]
 
 
 @pytest.fixture(scope="session")

--- a/sieves/tests/tasks/predictive/test_classification.py
+++ b/sieves/tests/tasks/predictive/test_classification.py
@@ -69,7 +69,6 @@ def _run(engine: engines.Engine, docs: list[Doc], fewshot: bool, multilabel: boo
     for doc in docs:
         assert doc.text
         assert doc.results["classifier"]
-        assert "classifier" in doc.results
 
 
 @pytest.mark.parametrize("batch_engine", EngineType.all(), indirect=["batch_engine"])


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Add single-label mode for classification task. Use label forcing for engines that support it.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
Resolves #131.

## Changes Made
<!-- List key changes in this PR -->
- Add single-label mode for classification task. Use label forcing for engines that support it.
- Slight refactoring of prompts and test cases.

## Checklist
- [x] Tests have been extended to cover changes in functionality
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
