### PR TITLE
Fix advanced example in README: add missing converter parameter for OCR task loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ import pickle
 import gliner.multitask
 import chonkie
 import tokenizers
+import docling.document_converter
 
 from sieves import Pipeline, Engine, tasks, Doc
 
@@ -160,7 +161,7 @@ with open("docs.pkl", "wb") as f:
 loaded_pipe = Pipeline.load(
     "pipeline.yml",
     (
-        {},
+        {"converter": docling.document_converter.DocumentConverter(), "export_format": "markdown"},
         {"chunker": chunker},
         {"engine": {"model": engine.model}},
     ),


### PR DESCRIPTION
## Summary
- Fixed missing converter parameter in advanced example that caused AssertionError when loading serialized pipeline with OCR task
- Added required import for docling.document_converter
- Updated Pipeline.load() call to include converter parameter in task_kwargs

## Test plan
- [x] Verified the fix matches the pattern shown in existing OCR serialization tests
- [x] Confirmed the converter parameter is marked as placeholder in serialization and required at load time
- [x] Updated example now matches the working pattern from test files

Fixes #150

🤖 Generated with [Claude Code](https://claude.ai/code)