### PR TITLE
feat: Allow `inference_mode` override

### DIFF
--- a/sieves/tasks/predictive/bridges.py
+++ b/sieves/tasks/predictive/bridges.py
@@ -18,17 +18,21 @@ TaskBridge = TypeVar("TaskBridge", bound="Bridge[TaskPromptSignature, TaskResult
 class Bridge(Generic[TaskPromptSignature, TaskResult, EngineInferenceMode], abc.ABC):
     """Bridge base class."""
 
-    def __init__(self, task_id: str, prompt_instructions: str | None, overwrite: bool):
+    def __init__(
+        self, task_id: str, prompt_instructions: str | None, overwrite: bool, inference_mode: EngineInferenceMode | None
+    ):
         """Initialize new bridge.
 
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param overwrite: Whether to overwrite text with produced text. Considered only by bridges for tasks producing
             fluent text - like translation, summarization, PII masking, etc.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         """
         self._task_id = task_id
         self._custom_prompt_instructions = prompt_instructions
         self._overwrite = overwrite
+        self._inference_mode = inference_mode
 
     @property
     @abc.abstractmethod
@@ -152,17 +156,14 @@ class GliXBridge(Bridge[list[str], glix_.Result, glix_.InferenceMode]):
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param prompt_signature: Prompt signature.
-        :param inference_mode: Inference mode.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         :param label_whitelist: Labels to record predictions for. If None, predictions for all labels are recorded.
         :param only_keep_best: Whether to only return the result with the highest score.
         """
         super().__init__(
-            task_id=task_id,
-            prompt_instructions=prompt_instructions,
-            overwrite=False,
+            task_id=task_id, prompt_instructions=prompt_instructions, overwrite=False, inference_mode=inference_mode
         )
         self._prompt_signature = prompt_signature
-        self._inference_mode = inference_mode
         self._label_whitelist = label_whitelist
         self._has_scores = inference_mode in (
             glix_.InferenceMode.classification,

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -23,6 +23,7 @@ from sieves.tasks.predictive.classification.bridges import (
     HuggingFaceClassification,
     LangChainClassification,
     OutlinesClassification,
+    TaskInferenceMode,
 )
 from sieves.tasks.predictive.core import FewshotExample as BaseFewshotExample
 from sieves.tasks.predictive.core import PredictiveTask
@@ -33,7 +34,6 @@ _TaskResult = str | pydantic.BaseModel | dspy_.Result | huggingface_.Result | gl
 _TaskBridge = (
     DSPyClassification | GliXBridge | LangChainClassification | HuggingFaceClassification | OutlinesClassification
 )
-_TaskInferenceMode = glix_.InferenceMode | dspy_.InferenceMode | huggingface_.InferenceMode | langchain_.InferenceMode
 
 
 class FewshotExampleMultiLabel(BaseFewshotExample):
@@ -98,7 +98,7 @@ class Classification(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBrid
         label_descriptions: dict[str, str] | None = None,
         multi_label: bool = True,
         generation_settings: GenerationSettings = GenerationSettings(),
-        inference_mode: _TaskInferenceMode | None = None,
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """Initialize new PredictiveTask.
 
@@ -179,6 +179,7 @@ class Classification(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBrid
                 labels=self._labels,
                 label_descriptions=self._label_descriptions,
                 multi_label=self._multi_label,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -124,9 +124,9 @@ class PredictiveTask(
         self._engine = init_engine(model, generation_settings)
         self._overwrite = overwrite
         self._custom_prompt_instructions = prompt_instructions
+        self._inference_mode = inference_mode
         self._bridge = self._init_bridge(EngineType.get_engine_type(self._engine))
         self._fewshot_examples = fewshot_examples
-        self._inference_mode = inference_mode
 
         self._validate_fewshot_examples()
 

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -22,6 +22,7 @@ from sieves.tasks.predictive.information_extraction.bridges import (
     DSPyInformationExtraction,
     LangChainInformationExtraction,
     OutlinesInformationExtraction,
+    TaskInferenceMode,
 )
 from sieves.tasks.utils import PydanticToHFDatasets
 
@@ -56,6 +57,7 @@ class InformationExtraction(PredictiveTask[_TaskPromptSignature, _TaskResult, _T
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """Initialize new PredictiveTask.
 
@@ -67,6 +69,7 @@ class InformationExtraction(PredictiveTask[_TaskPromptSignature, _TaskResult, _T
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._entity_type = entity_type
 
@@ -79,6 +82,7 @@ class InformationExtraction(PredictiveTask[_TaskPromptSignature, _TaskResult, _T
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
 
         if not self._entity_type.model_config.get("frozen", False):
@@ -106,6 +110,7 @@ class InformationExtraction(PredictiveTask[_TaskPromptSignature, _TaskResult, _T
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 entity_type=self._entity_type,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/ner/bridges.py
+++ b/sieves/tasks/predictive/ner/bridges.py
@@ -16,6 +16,7 @@ from sieves.tasks.predictive.bridges import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature")
 _BridgeResult = TypeVar("_BridgeResult")
+TaskInferenceMode = dspy_.InferenceMode | glix_.InferenceMode | langchain_.InferenceMode | outlines_.InferenceMode
 
 
 class Entity(pydantic.BaseModel):
@@ -65,16 +66,19 @@ class NERBridge(Bridge[_BridgePromptSignature, _BridgeResult, EngineInferenceMod
         entities: list[str],
         task_id: str,
         prompt_instructions: str | None,
+        inference_mode: TaskInferenceMode | None,
     ):
         """Initialize NERBridge.
 
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         """
         super().__init__(
             task_id=task_id,
             prompt_instructions=prompt_instructions,
             overwrite=False,
+            inference_mode=inference_mode,
         )
         self._entities = entities
 
@@ -242,7 +246,7 @@ class DSPyNER(NERBridge[dspy_.PromptSignature, dspy_.Result, dspy_.InferenceMode
     @override
     @property
     def inference_mode(self) -> dspy_.InferenceMode:
-        return dspy_.InferenceMode.predict
+        return self._inference_mode or dspy_.InferenceMode.predict
 
     @override
     def consolidate(
@@ -380,7 +384,7 @@ class OutlinesNER(PydanticBasedNER[outlines_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> outlines_.InferenceMode:
-        return outlines_.InferenceMode.json
+        return self._inference_mode or outlines_.InferenceMode.json
 
 
 class LangChainNER(PydanticBasedNER[langchain_.InferenceMode]):
@@ -389,7 +393,7 @@ class LangChainNER(PydanticBasedNER[langchain_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> langchain_.InferenceMode:
-        return langchain_.InferenceMode.structured
+        return self._inference_mode or langchain_.InferenceMode.structured
 
 
 class GliXNER(NERBridge[list[str], glix_.Result, glix_.InferenceMode]):
@@ -400,17 +404,17 @@ class GliXNER(NERBridge[list[str], glix_.Result, glix_.InferenceMode]):
         entities: list[str],
         task_id: str,
         prompt_instructions: str | None,
+        inference_mode: glix_.InferenceMode | None,
     ):
         """Initialize GliXNER bridge.
 
         :param entities: List of entity types to extract.
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         """
         super().__init__(
-            entities=entities,
-            task_id=task_id,
-            prompt_instructions=prompt_instructions,
+            entities=entities, task_id=task_id, prompt_instructions=prompt_instructions, inference_mode=inference_mode
         )
 
     @override
@@ -436,7 +440,7 @@ class GliXNER(NERBridge[list[str], glix_.Result, glix_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> glix_.InferenceMode:
-        return glix_.InferenceMode.ner
+        return self._inference_mode or glix_.InferenceMode.ner
 
     @override
     def consolidate(

--- a/sieves/tasks/predictive/ner/core.py
+++ b/sieves/tasks/predictive/ner/core.py
@@ -29,6 +29,7 @@ from sieves.tasks.predictive.ner.bridges import (
     GliXNER,
     LangChainNER,
     OutlinesNER,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | glix_.Model | langchain_.Model | outlines_.Model
@@ -79,6 +80,7 @@ class NER(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]):
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """
         Initialize NER task.
@@ -91,6 +93,7 @@ class NER(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]):
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._entities = entities or ["PERSON", "LOCATION", "ORGANIZATION"]
         super().__init__(
@@ -102,6 +105,7 @@ class NER(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]):
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
         self._fewshot_examples: Sequence[FewshotExample]
 
@@ -119,6 +123,7 @@ class NER(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]):
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 entities=self._entities,
+                inference_mode=self._inference_mode,
             )
             return result  # type: ignore[return-value]
         except KeyError as err:

--- a/sieves/tasks/predictive/pii_masking/core.py
+++ b/sieves/tasks/predictive/pii_masking/core.py
@@ -19,6 +19,7 @@ from sieves.tasks.predictive.pii_masking.bridges import (
     DSPyPIIMasking,
     LangChainPIIMasking,
     OutlinesPIIMasking,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | langchain_.Model | outlines_.Model
@@ -62,6 +63,7 @@ class PIIMasking(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge])
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """
         Initialize PIIMasking task.
@@ -78,6 +80,7 @@ class PIIMasking(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge])
             task's default template is used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._pii_types = pii_types
         self._mask_placeholder = mask_placeholder
@@ -91,6 +94,7 @@ class PIIMasking(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge])
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
 
     @override
@@ -108,6 +112,7 @@ class PIIMasking(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge])
                 mask_placeholder=self._mask_placeholder,
                 pii_types=self._pii_types,
                 overwrite=self._overwrite,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/question_answering/bridges.py
+++ b/sieves/tasks/predictive/question_answering/bridges.py
@@ -10,27 +10,36 @@ import jinja2
 import pydantic
 
 from sieves.data import Doc
-from sieves.engines import EngineInferenceMode, dspy_, langchain_, outlines_
+from sieves.engines import EngineInferenceMode, dspy_, glix_, langchain_, outlines_
 from sieves.tasks.predictive.bridges import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature")
 _BridgeResult = TypeVar("_BridgeResult")
+TaskInferenceMode = dspy_.InferenceMode | glix_.InferenceMode | langchain_.InferenceMode | outlines_.InferenceMode
 
 
 class QABridge(Bridge[_BridgePromptSignature, _BridgeResult, EngineInferenceMode], abc.ABC):
     """Abstract base class for question answering bridges."""
 
-    def __init__(self, task_id: str, prompt_instructions: str | None, questions: list[str]):
+    def __init__(
+        self,
+        task_id: str,
+        prompt_instructions: str | None,
+        questions: list[str],
+        inference_mode: TaskInferenceMode | None,
+    ):
         """Initialize QuestionAnsweringBridge.
 
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param questions: Questions to answer.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         """
         super().__init__(
             task_id=task_id,
             prompt_instructions=prompt_instructions,
             overwrite=False,
+            inference_mode=inference_mode,
         )
         self._questions = questions
 
@@ -85,7 +94,7 @@ class DSPyQA(QABridge[dspy_.PromptSignature, dspy_.Result, dspy_.InferenceMode])
     @override
     @property
     def inference_mode(self) -> dspy_.InferenceMode:
-        return dspy_.InferenceMode.chain_of_thought
+        return self._inference_mode or dspy_.InferenceMode.predict
 
     @override
     def integrate(self, results: Iterable[dspy_.Result], docs: Iterable[Doc]) -> Iterable[Doc]:
@@ -218,7 +227,7 @@ class OutlinesQA(PydanticBasedQA[outlines_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> outlines_.InferenceMode:
-        return outlines_.InferenceMode.json
+        return self._inference_mode or outlines_.InferenceMode.json
 
 
 class LangChainQA(PydanticBasedQA[langchain_.InferenceMode]):
@@ -227,4 +236,4 @@ class LangChainQA(PydanticBasedQA[langchain_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> langchain_.InferenceMode:
-        return langchain_.InferenceMode.structured
+        return self._inference_mode or langchain_.InferenceMode.structured

--- a/sieves/tasks/predictive/question_answering/core.py
+++ b/sieves/tasks/predictive/question_answering/core.py
@@ -21,6 +21,7 @@ from sieves.tasks.predictive.question_answering.bridges import (
     DSPyQA,
     LangChainQA,
     OutlinesQA,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | glix_.Model | langchain_.Model | outlines_.Model
@@ -60,6 +61,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """
         Initialize QuestionAnswering task.
@@ -72,6 +74,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._questions = questions
         super().__init__(
@@ -83,6 +86,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
         self._fewshot_examples: Sequence[FewshotExample]
 
@@ -93,7 +97,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 prompt_signature=self._questions,
-                inference_mode=glix_.InferenceMode.question_answering,
+                inference_mode=self._inference_mode or glix_.InferenceMode.question_answering,
             )
 
         bridge_types: dict[EngineType, type[_TaskBridge]] = {
@@ -110,6 +114,7 @@ class QuestionAnswering(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 questions=self._questions,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/sentiment_analysis/core.py
+++ b/sieves/tasks/predictive/sentiment_analysis/core.py
@@ -21,6 +21,7 @@ from sieves.tasks.predictive.sentiment_analysis.bridges import (
     DSPySentimentAnalysis,
     LangChainSentimentAnalysis,
     OutlinesSentimentAnalysis,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | langchain_.Model | outlines_.Model
@@ -64,6 +65,7 @@ class SentimentAnalysis(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
         batch_size: int = -1,
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """
         Initialize SentimentAnalysis task.
@@ -77,6 +79,7 @@ class SentimentAnalysis(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
         :param batch_size: Batch size to use for inference. Use -1 to process all documents at once.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._aspects = tuple(sorted(set(aspects) | {"overall"}))
         super().__init__(
@@ -88,6 +91,7 @@ class SentimentAnalysis(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
             overwrite=False,
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
+            inference_mode=inference_mode,
         )
         self._fewshot_examples: Sequence[FewshotExample]
 
@@ -106,6 +110,7 @@ class SentimentAnalysis(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskB
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 aspects=self._aspects,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/summarization/core.py
+++ b/sieves/tasks/predictive/summarization/core.py
@@ -21,6 +21,7 @@ from sieves.tasks.predictive.summarization.bridges import (
     DSPySummarization,
     LangChainSummarization,
     OutlinesSummarization,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | glix_.Model | langchain_.Model | outlines_.Model
@@ -55,6 +56,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """Initialize new Summarization task.
 
@@ -69,6 +71,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._n_words = n_words
 
@@ -81,6 +84,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
 
     @override
@@ -90,7 +94,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
                 task_id=self._task_id,
                 prompt_instructions=self._custom_prompt_instructions,
                 prompt_signature=[],
-                inference_mode=glix_.InferenceMode.summarization,
+                inference_mode=self._inference_mode or glix_.InferenceMode.summarization,
             )
 
         bridge_types: dict[EngineType, type[_TaskBridge]] = {
@@ -108,6 +112,7 @@ class Summarization(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridg
                 prompt_instructions=self._custom_prompt_instructions,
                 overwrite=self._overwrite,
                 n_words=self._n_words,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tasks/predictive/translation/bridges.py
+++ b/sieves/tasks/predictive/translation/bridges.py
@@ -15,6 +15,7 @@ from sieves.tasks.predictive.bridges import Bridge
 
 _BridgePromptSignature = TypeVar("_BridgePromptSignature")
 _BridgeResult = TypeVar("_BridgeResult")
+TaskInferenceMode = dspy_.InferenceMode | langchain_.InferenceMode | outlines_.InferenceMode
 
 
 class TranslationBridge(
@@ -29,18 +30,21 @@ class TranslationBridge(
         prompt_instructions: str | None,
         overwrite: bool,
         language: str,
+        inference_mode: TaskInferenceMode | None,
     ):
-        """Initialize InformationExtractionBridge.
+        """Initialize TranslationBridge.
 
         :param task_id: Task ID.
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param overwrite: Whether to overwrite text with translation.
         :param language: Language to translate to.
+        :param inference_mode: Inference mode. If None, the default inference mode is used.
         """
         super().__init__(
             task_id=task_id,
             prompt_instructions=prompt_instructions,
             overwrite=overwrite,
+            inference_mode=inference_mode,
         )
         self._to = language
 
@@ -85,7 +89,7 @@ class DSPyTranslation(TranslationBridge[dspy_.PromptSignature, dspy_.Result, dsp
     @override
     @property
     def inference_mode(self) -> dspy_.InferenceMode:
-        return dspy_.InferenceMode.predict
+        return self._inference_mode or dspy_.InferenceMode.predict
 
     @override
     def integrate(self, results: Iterable[dspy_.Result], docs: Iterable[Doc]) -> Iterable[Doc]:
@@ -209,7 +213,7 @@ class OutlinesTranslation(PydanticBasedTranslation[outlines_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> outlines_.InferenceMode:
-        return outlines_.InferenceMode.json
+        return self._inference_mode or outlines_.InferenceMode.json
 
 
 class LangChainTranslation(PydanticBasedTranslation[langchain_.InferenceMode]):
@@ -218,4 +222,4 @@ class LangChainTranslation(PydanticBasedTranslation[langchain_.InferenceMode]):
     @override
     @property
     def inference_mode(self) -> langchain_.InferenceMode:
-        return langchain_.InferenceMode.structured
+        return self._inference_mode or langchain_.InferenceMode.structured

--- a/sieves/tasks/predictive/translation/core.py
+++ b/sieves/tasks/predictive/translation/core.py
@@ -20,6 +20,7 @@ from sieves.tasks.predictive.translation.bridges import (
     DSPyTranslation,
     LangChainTranslation,
     OutlinesTranslation,
+    TaskInferenceMode,
 )
 
 _TaskModel = dspy_.Model | langchain_.Model | outlines_.Model
@@ -59,6 +60,7 @@ class Translation(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]
         prompt_instructions: str | None = None,
         fewshot_examples: Sequence[FewshotExample] = (),
         generation_settings: GenerationSettings = GenerationSettings(),
+        inference_mode: TaskInferenceMode | None = None,
     ) -> None:
         """
         Initialize Translation task.
@@ -74,6 +76,7 @@ class Translation(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]
         :param prompt_instructions: Custom prompt instructions. If None, default instructions are used.
         :param fewshot_examples: Few-shot examples.
         :param generation_settings: Settings for structured generation.
+        :param inference_mode: Inference mode to use. If None, the default mode for this task will be used.
         """
         self._to = to
 
@@ -86,6 +89,7 @@ class Translation(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]
             prompt_instructions=prompt_instructions,
             fewshot_examples=fewshot_examples,
             generation_settings=generation_settings,
+            inference_mode=inference_mode,
         )
 
     @override
@@ -102,6 +106,7 @@ class Translation(PredictiveTask[_TaskPromptSignature, _TaskResult, _TaskBridge]
                 prompt_instructions=self._custom_prompt_instructions,
                 overwrite=self._overwrite,
                 language=self._to,
+                inference_mode=self._inference_mode,
             )
         except KeyError as err:
             raise KeyError(f"Engine type {engine_type} is not supported by {self.__class__.__name__}.") from err

--- a/sieves/tests/tasks/predictive/test_classification.py
+++ b/sieves/tests/tasks/predictive/test_classification.py
@@ -5,11 +5,11 @@ import pydantic
 import pytest
 
 from sieves import Doc, Pipeline, engines
-from sieves.engines import EngineType
+from sieves.engines import EngineType, dspy_, langchain_, outlines_, huggingface_, glix_
 from sieves.serialization import Config
 from sieves.tasks import PredictiveTask
 from sieves.tasks.predictive import classification
-from sieves.tests.conftest import Runtime, _make_runtime
+from sieves.tests.conftest import Runtime
 
 
 def _run(runtime: Runtime, docs: list[Doc], fewshot: bool, multilabel: bool = True) -> None:
@@ -300,3 +300,20 @@ def test_result_to_scores() -> None:
             not_label: str
 
         classification.Classification._result_to_scores(BadPRes(not_label="x"))
+
+
+@pytest.mark.parametrize("batch_runtime", EngineType.all(), indirect=["batch_runtime"])
+def test_inference_mode_override(batch_runtime) -> None:
+    """Test that inference_mode parameter overrides the default value."""
+    dummy = "dummy_inference_mode"
+
+    task = classification.Classification(
+        task_id="classifier",
+        labels=["science", "politics"],
+        model=batch_runtime.model,
+        generation_settings=batch_runtime.generation_settings,
+        batch_size=batch_runtime.batch_size,
+        inference_mode=dummy,
+    )
+
+    assert task._bridge.inference_mode == dummy

--- a/sieves/tests/tasks/predictive/test_ner.py
+++ b/sieves/tests/tasks/predictive/test_ner.py
@@ -128,3 +128,23 @@ def test_to_hf_dataset(ner_docs, batch_runtime) -> None:
 
     with pytest.raises(KeyError):
         task.to_hf_dataset([Doc(text="This is a dummy text.")])
+
+
+@pytest.mark.parametrize(
+    "batch_runtime",
+    [EngineType.dspy, EngineType.langchain, EngineType.outlines, EngineType.glix],
+    indirect=["batch_runtime"],
+)
+def test_inference_mode_override(batch_runtime) -> None:
+    """Test that inference_mode parameter overrides the default value."""
+    dummy = "dummy_inference_mode"
+
+    task = ner.NER(
+        entities=["PERSON", "LOCATION", "COMPANY"],
+        model=batch_runtime.model,
+        generation_settings=batch_runtime.generation_settings,
+        batch_size=batch_runtime.batch_size,
+        inference_mode=dummy,
+    )
+
+    assert task._bridge.inference_mode == dummy

--- a/sieves/tests/tasks/predictive/test_pii_masking.py
+++ b/sieves/tests/tasks/predictive/test_pii_masking.py
@@ -2,7 +2,7 @@
 import pytest
 
 from sieves import Doc, Pipeline, tasks
-from sieves.engines import EngineType
+from sieves.engines import EngineType, dspy_, langchain_, outlines_
 from sieves.serialization import Config
 from sieves.tasks import PredictiveTask
 from sieves.tasks.predictive import pii_masking
@@ -114,3 +114,22 @@ def test_serialization(pii_masking_docs, batch_runtime) -> None:
  'version': Config.get_version()}
 
     Pipeline.deserialize(config=config, tasks_kwargs=[{"model": batch_runtime.model}])
+
+
+@pytest.mark.parametrize(
+    "batch_runtime",
+    [EngineType.dspy, EngineType.langchain, EngineType.outlines],
+    indirect=["batch_runtime"],
+)
+def test_inference_mode_override(batch_runtime) -> None:
+    """Test that inference_mode parameter overrides the default value."""
+    dummy = "dummy_inference_mode"
+
+    task = tasks.predictive.PIIMasking(
+        model=batch_runtime.model,
+        generation_settings=batch_runtime.generation_settings,
+        batch_size=batch_runtime.batch_size,
+        inference_mode=dummy,
+    )
+
+    assert task._bridge.inference_mode == dummy

--- a/sieves/tests/tasks/predictive/test_sentiment_analysis.py
+++ b/sieves/tests/tasks/predictive/test_sentiment_analysis.py
@@ -2,7 +2,7 @@
 import pytest
 
 from sieves import Doc, Pipeline
-from sieves.engines import EngineType
+from sieves.engines import EngineType, dspy_, langchain_, outlines_
 from sieves.serialization import Config
 from sieves.tasks import PredictiveTask
 from sieves.tasks.predictive import sentiment_analysis
@@ -127,3 +127,24 @@ def test_serialization(dummy_docs, batch_runtime) -> None:
  'version': Config.get_version()}
 
     Pipeline.deserialize(config=config, tasks_kwargs=[{"model": batch_runtime.model}])
+
+
+@pytest.mark.parametrize(
+    "batch_runtime",
+    [EngineType.dspy, EngineType.langchain, EngineType.outlines],
+    indirect=["batch_runtime"],
+)
+def test_inference_mode_override(batch_runtime) -> None:
+    """Test that inference_mode parameter overrides the default value."""
+    dummy = "dummy_inference_mode"
+
+    task = sentiment_analysis.SentimentAnalysis(
+        task_id="sentiment_analysis",
+        aspects=("food", "service"),
+        model=batch_runtime.model,
+        generation_settings=batch_runtime.generation_settings,
+        batch_size=batch_runtime.batch_size,
+        inference_mode=dummy,
+    )
+
+    assert task._bridge.inference_mode == dummy

--- a/sieves/tests/tasks/predictive/test_summarization.py
+++ b/sieves/tests/tasks/predictive/test_summarization.py
@@ -2,7 +2,7 @@
 import pytest
 
 from sieves import Doc, Pipeline
-from sieves.engines import EngineType
+from sieves.engines import EngineType, dspy_, langchain_, outlines_
 from sieves.serialization import Config
 from sieves.tasks import PredictiveTask
 from sieves.tasks.predictive import summarization
@@ -121,3 +121,23 @@ def test_serialization(summarization_docs, batch_runtime) -> None:
  'version': Config.get_version()}
 
     Pipeline.deserialize(config=config, tasks_kwargs=[{"model": batch_runtime.model}])
+
+
+@pytest.mark.parametrize(
+    "batch_runtime",
+    [EngineType.dspy, EngineType.langchain, EngineType.outlines],
+    indirect=["batch_runtime"],
+)
+def test_inference_mode_override(batch_runtime) -> None:
+    """Test that inference_mode parameter overrides the default value."""
+    dummy = "dummy_inference_mode"
+
+    task = summarization.Summarization(
+        n_words=10,
+        model=batch_runtime.model,
+        generation_settings=batch_runtime.generation_settings,
+        batch_size=batch_runtime.batch_size,
+        inference_mode=dummy,
+    )
+
+    assert task._bridge.inference_mode == dummy


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Allow override of `inference_mode` on `PredictiveTask` level.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
\-

## Changes Made
<!-- List key changes in this PR -->
- Allows override of `inference_mode` on `PredictiveTask` level.
- Changes DSPy default inference mode to `predict` from `chain_of_thought`
- Make `reasoning` output optional for DSPy

## Checklist
- ~[ ] Tests have been extended to cover changes in functionality~
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
