### PR TITLE
feat: Remove reasoning fields

### DIFF
--- a/docs/guides/optimization.md
+++ b/docs/guides/optimization.md
@@ -44,13 +44,11 @@ model = dspy.LM("claude-3-haiku-20240307", api_key=os.environ["ANTHROPIC_API_KEY
 examples = [
     Classification.FewshotExampleSingleLabel(
         text="The new AI model achieves state-of-the-art results",
-        reasoning="Discusses AI technology advancement",
         label="technology",
         confidence=1.0
     ),
     Classification.FewshotExampleSingleLabel(
         text="Election results show significant voter turnout",
-        reasoning="Focuses on electoral process and voting",
         label="politics",
         confidence=1.0
     ),
@@ -184,7 +182,6 @@ model = dspy.LM("claude-3-haiku-20240307", api_key="...")
 examples = [
     Classification.FewshotExampleMultiLabel(
         text="Quantum computing advances promise faster drug discovery",
-        reasoning="Combines technology (quantum computing) and healthcare (drug discovery)",
         confidence_per_label={"technology": 0.9, "healthcare": 0.7, "finance": 0.1}
     ),
     # ... more examples

--- a/sieves/tasks/predictive/classification/core.py
+++ b/sieves/tasks/predictive/classification/core.py
@@ -39,7 +39,6 @@ _TaskBridge = (
 class FewshotExampleMultiLabel(BaseFewshotExample):
     """Few‑shot example for multi‑label classification with per‑label confidences."""
 
-    reasoning: str | None = None
     confidence_per_label: dict[str, float]
 
     @override
@@ -58,7 +57,6 @@ class FewshotExampleMultiLabel(BaseFewshotExample):
 class FewshotExampleSingleLabel(BaseFewshotExample):
     """Few‑shot example for single‑label classification with a global confidence."""
 
-    reasoning: str | None = None
     label: str
     confidence: float
 

--- a/sieves/tasks/predictive/core.py
+++ b/sieves/tasks/predictive/core.py
@@ -35,10 +35,6 @@ class EvaluationSignature(dspy.Signature):
     ground_truth: str = dspy.InputField(desc="Ground truth output values.")
     prediction: str = dspy.InputField(desc="Predicted output values.")
 
-    reasoning: str | None = dspy.OutputField(
-        desc="Step-by-step reasoning for the similarity assessment. Provide this when the assessment is non-trivial.",
-        default=None,
-    )
     similarity_score: float = dspy.OutputField(
         desc="Similarity score between 0.0 and 1.0, where 1.0 means identical and 0.0 means completely different."
     )
@@ -412,7 +408,7 @@ class PredictiveTask(
         dspy_examples = [ex.to_dspy() for ex in self._fewshot_examples]
 
         def _pred_eval(truth: dspy.Example, pred: dspy.Prediction, trace: Any | None = None) -> float:
-            """Wraps optimization evaluator, injects model.
+            """Wraps optimization evaluation, injects model.
 
             :param truth: Ground truth.
             :param pred: Predicted value.

--- a/sieves/tasks/predictive/information_extraction/core.py
+++ b/sieves/tasks/predictive/information_extraction/core.py
@@ -36,7 +36,6 @@ _TaskBridge = GliNERBridge | DSPyInformationExtraction | LangChainInformationExt
 class FewshotExample(BaseFewshotExample):
     """Few-shot example."""
 
-    reasoning: str | None = None
     entities: list[pydantic.BaseModel]
 
     @override

--- a/sieves/tasks/predictive/ner/bridges.py
+++ b/sieves/tasks/predictive/ner/bridges.py
@@ -251,9 +251,6 @@ class DSPyNER(NERBridge[dspy_.PromptSignature, dspy_.Result, dspy_.InferenceMode
             text: str = dspy.InputField(description="Text to extract entities from")
             entity_types: list[str] = dspy.InputField(description="List of entity types to extract")
 
-            reasoning: str | None = dspy.OutputField(
-                default=None, description="Provide reasoning for complex entity extraction decisions."
-            )
             entities: list[Entity] = dspy.OutputField(
                 description="List of entities found in the text. If the same entity appears multiple times "
                 "in different contexts, include each occurrence separately."
@@ -367,9 +364,6 @@ class PydanticBasedNER(NERBridge[pydantic.BaseModel, pydantic.BaseModel, EngineI
         class Prediction(pydantic.BaseModel):
             """NER prediction."""
 
-            reasoning: str | None = pydantic.Field(
-                default=None, description="Provide reasoning for complex entity extraction decisions."
-            )
             entities: list[EntityWithContext] = []
 
         return Prediction

--- a/sieves/tasks/predictive/pii_masking/core.py
+++ b/sieves/tasks/predictive/pii_masking/core.py
@@ -37,7 +37,6 @@ class PIIEntity(pydantic.BaseModel, frozen=True):
 class FewshotExample(BaseFewshotExample):
     """Example for PII masking few-shot prompting."""
 
-    reasoning: str | None = None
     masked_text: str
     pii_entities: list[PIIEntity]
 

--- a/sieves/tasks/predictive/question_answering/core.py
+++ b/sieves/tasks/predictive/question_answering/core.py
@@ -31,7 +31,6 @@ _TaskBridge = DSPyQA | LangChainQA | OutlinesQA
 class FewshotExample(BaseFewshotExample):
     """Few-shot example with questions and answers for a context."""
 
-    reasoning: str | None = None
     questions: tuple[str, ...] | list[str]
     answers: tuple[str, ...] | list[str]
 

--- a/sieves/tasks/predictive/sentiment_analysis/core.py
+++ b/sieves/tasks/predictive/sentiment_analysis/core.py
@@ -34,7 +34,6 @@ _TaskBridge = GliNERBridge | DSPySentimentAnalysis | LangChainSentimentAnalysis 
 class FewshotExample(BaseFewshotExample):
     """Few-shot example with per-aspect sentiment scores."""
 
-    reasoning: str | None = None
     sentiment_per_aspect: dict[str, float]
 
     @override

--- a/sieves/tasks/predictive/summarization/bridges.py
+++ b/sieves/tasks/predictive/summarization/bridges.py
@@ -77,9 +77,6 @@ class DSPySummarization(SummarizationBridge[dspy_.PromptSignature, dspy_.Result,
         class Summary(dspy.Signature):  # type: ignore[misc]
             text: str = dspy.InputField(description="Text to summarize.")
             n_words: str = dspy.InputField(description="Number of words to approximately use for summary.")
-            reasoning: str | None = dspy.OutputField(
-                default=None, description="Provide reasoning for summarization choices when appropriate."
-            )
             summary: str = dspy.OutputField(description="Summary of text.")
 
         Summary.__doc__ = jinja2.Template(self._prompt_instructions).render()
@@ -169,9 +166,6 @@ class PydanticBasedSummarization(
         class Summary(pydantic.BaseModel, frozen=True):
             """Summary of the specified text."""
 
-            reasoning: str | None = pydantic.Field(
-                default=None, description="Provide reasoning for summarization choices when appropriate."
-            )
             summary: str
 
         return Summary

--- a/sieves/tasks/predictive/translation/bridges.py
+++ b/sieves/tasks/predictive/translation/bridges.py
@@ -77,9 +77,6 @@ class DSPyTranslation(TranslationBridge[dspy_.PromptSignature, dspy_.Result, dsp
         class Translation(dspy.Signature):  # type: ignore[misc]
             text: str = dspy.InputField()
             target_language: str = dspy.InputField()
-            reasoning: str | None = dspy.OutputField(
-                default=None, description="Provide reasoning for translation choices when relevant."
-            )
             translation: str = dspy.OutputField()
 
         Translation.__doc__ = jinja2.Template(self._prompt_instructions).render()
@@ -170,9 +167,6 @@ class PydanticBasedTranslation(
         class Translation(pydantic.BaseModel, frozen=True):
             """Translation."""
 
-            reasoning: str | None = pydantic.Field(
-                default=None, description="Provide reasoning for translation choices when relevant."
-            )
             translation: str
 
         return Translation

--- a/sieves/tests/tasks/predictive/test_classification.py
+++ b/sieves/tests/tasks/predictive/test_classification.py
@@ -17,14 +17,10 @@ def _run(runtime: Runtime, docs: list[Doc], fewshot: bool, multilabel: bool = Tr
         fewshot_examples = [
             classification.FewshotExampleMultiLabel(
                 text="On the properties of hydrogen atoms and red dwarfs.",
-                reasoning="Atoms, hydrogen and red dwarfs are terms from physics. There is no mention of any "
-                "politics-related terms.",
                 confidence_per_label={"science": 1.0, "politics": 0.0},
             ),
             classification.FewshotExampleMultiLabel(
                 text="A parliament is elected by casting votes.",
-                reasoning="The election of a parliament by the casting of votes is a component of a democratic "
-                "political system.",
                 confidence_per_label={"science": 0, "politics": 1.0},
             ),
         ]
@@ -32,15 +28,11 @@ def _run(runtime: Runtime, docs: list[Doc], fewshot: bool, multilabel: bool = Tr
         fewshot_examples = [
             classification.FewshotExampleSingleLabel(
                 text="On the properties of hydrogen atoms and red dwarfs.",
-                reasoning="Atoms, hydrogen and red dwarfs are terms from physics. There is no mention of any "
-                "politics-related terms. This is about science - scientists, papers, experiments, laws of nature.",
                 label="science",
                 confidence=1.0,
             ),
             classification.FewshotExampleSingleLabel(
                 text="A parliament is elected by casting votes.",
-                reasoning="The election of a parliament by the casting of votes is a component of a democratic "
-                "political system. This is about politics - parliament, laws, parties, politicians.",
                 label="politics",
                 confidence=1.0,
             ),
@@ -232,7 +224,6 @@ def test_fewshot_example_singlelabel_confidence() -> None:
     """Test that the confidence of a fewshot example is correctly validated."""
     classification.FewshotExampleSingleLabel(
         text="...",
-        reasoning="...",
         label="science",
         confidence=1.0,
     )
@@ -240,7 +231,6 @@ def test_fewshot_example_singlelabel_confidence() -> None:
     with pytest.raises(ValueError):
         classification.FewshotExampleSingleLabel(
             text="...",
-            reasoning="...",
             label="science",
             confidence=2.0,
         )
@@ -248,7 +238,6 @@ def test_fewshot_example_singlelabel_confidence() -> None:
     with pytest.raises(ValueError):
         classification.FewshotExampleSingleLabel(
             text="...",
-            reasoning="...",
             label="science",
             confidence=-2.0,
         )

--- a/sieves/tests/tasks/predictive/test_information_extraction.py
+++ b/sieves/tests/tasks/predictive/test_information_extraction.py
@@ -33,12 +33,10 @@ def test_run(information_extraction_docs, batch_runtime, fewshot) -> None:
     fewshot_examples = [
         information_extraction.FewshotExample(
             text="Ada Lovelace lived to 47 years old. Zeno of Citium died with 72 years.",
-            reasoning="There is mention of two people in this text, including lifespans. I will extract those.",
             entities=[Person(name="Ada Lovelace", age=47), Person(name="Zeno of Citium", age=72)],
         ),
         information_extraction.FewshotExample(
             text="Alan Watts passed away at the age of 58 years. Alan Watts was 58 years old at the time of his death.",
-            reasoning="There is mention of one person in this text, including lifespan. I will extract this person.",
             entities=[Person(name="Alan Watts", age=58)],
         ),
     ]

--- a/sieves/tests/tasks/predictive/test_pii_masking.py
+++ b/sieves/tests/tasks/predictive/test_pii_masking.py
@@ -22,13 +22,11 @@ def test_run(pii_masking_docs, batch_runtime, fewshot) -> None:
     fewshot_examples = [
         pii_masking.FewshotExample(
             text="Jane Smith works at NASA.",
-            reasoning="Jane Smith is a person's name and should be masked.",
             masked_text="[MASKED] works at NASA.",
             pii_entities=[pii_masking.PIIEntity(entity_type="PERSON", text="Jane Smith")],
         ),
         pii_masking.FewshotExample(
             text="He lives at Diagon Alley 37.",
-            reasoning="Diagon Alley 37 is a residential address and should be masked.",
             masked_text="He lives at [MASKED].",
             pii_entities=[pii_masking.PIIEntity(entity_type="ADDRESS", text="Diagon Alley 37")],
         ),

--- a/sieves/tests/tasks/predictive/test_question_answering.py
+++ b/sieves/tests/tasks/predictive/test_question_answering.py
@@ -26,7 +26,6 @@ def test_run(qa_docs, batch_runtime, fewshot):
             space and time, and the related entities of energy and force. Physics is one of the most fundamental
             scientific disciplines. A scientist who specializes in the field of physics is called a physicist.
             """,
-            reasoning="The text states ad verbatim what a scientist specializing in physics is called.",
             questions=("What's a scientist called who specializes in the field of physics?",),
             answers=("A physicist.",),
         ),
@@ -37,7 +36,6 @@ def test_run(qa_docs, batch_runtime, fewshot):
             populations. They usually specialize in a particular branch (e.g., molecular biology, zoology, and
             evolutionary biology) of biology and have a specific research focus (e.g., studying malaria or cancer).
             """,
-            reasoning="The states ad verbatim that biologists are interested in studying life on earth.",
             questions=("What are biologists interested in?",),
             answers=("Studying life on earth.",),
         ),

--- a/sieves/tests/tasks/predictive/test_sentiment_analysis.py
+++ b/sieves/tests/tasks/predictive/test_sentiment_analysis.py
@@ -23,15 +23,11 @@ def test_run(sentiment_analysis_docs, batch_runtime, fewshot):
     fewshot_examples = [
         sentiment_analysis.FewshotExample(
             text="The food was perfect, the service only ok.",
-            reasoning="The text is very positive about the quality of the food, and neutral about the service quality."
-            " The overall sentiment is hence positive.",
             sentiment_per_aspect={"food": 1.0, "service": 0.5, "overall": 0.8},
         ),
         sentiment_analysis.FewshotExample(
             text="The service was amazing - they take excellent care of their customers. The food was despicable "
             "though, I strongly recommend not to go.",
-            reasoning="While the service is judged as amazing, hence very positive, the assessment of the food is very "
-            "negative. The overall sentiment is strongly negative.",
             sentiment_per_aspect={"food": 0.1, "service": 1.0, "overall": 0.3},
         ),
     ]

--- a/sieves/tests/tasks/test_optimization.py
+++ b/sieves/tests/tasks/test_optimization.py
@@ -42,59 +42,49 @@ def optimizer(request) -> Optimizer:
 
 def test_optimization_classification(optimizer) -> None:
     """Tests optimization for classification tasks."""
-    rf = 'Is a fruit.'
-    rv = 'Is a vegetable.'
     examples_single_label = [
-        classification.FewshotExampleSingleLabel(text='Apple', reasoning=rf, label='fruit', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Broccoli', reasoning=rv, label='vegetable', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Melon', reasoning=rf, label='fruit', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Carrot', reasoning=rv, label='vegetable', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Tomato', reasoning=rf, label='fruit', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Pepper', reasoning=rv, label='vegetable',
+        classification.FewshotExampleSingleLabel(text='Apple', label='fruit', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Broccoli', label='vegetable', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Melon', label='fruit', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Carrot', label='vegetable', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Tomato', label='fruit', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Pepper', label='vegetable',
                                                  confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Kiwi', reasoning=rf, label='fruit', confidence=1.),
-        classification.FewshotExampleSingleLabel(text='Onion', reasoning=rv, label='vegetable',
+        classification.FewshotExampleSingleLabel(text='Kiwi', label='fruit', confidence=1.),
+        classification.FewshotExampleSingleLabel(text='Onion', label='vegetable',
                                                  confidence=1.),
     ]
     examples_multi_label = [
         classification.FewshotExampleMultiLabel(
             text='Ghostbusters',
-            reasoning='A group of scientists battle paranormal entities with humor and sci-fi equipment.',
             confidence_per_label={'comedy': 0.9, 'scifi': 0.8}
         ),
         classification.FewshotExampleMultiLabel(
             text='The Martian',
-            reasoning='A stranded astronaut uses science and wit to survive on Mars with comedic moments.',
             confidence_per_label={'comedy': 0.4, 'scifi': 1.0}
         ),
         classification.FewshotExampleMultiLabel(
             text='Galaxy Quest',
-            reasoning='A comedy about actors from a sci-fi show who encounter real aliens.',
             confidence_per_label={'comedy': 1.0, 'scifi': 0.9}
         ),
         classification.FewshotExampleMultiLabel(
             text='Back to the Future',
-            reasoning='Time travel adventure with comedic family dynamics and sci-fi concepts.',
             confidence_per_label={'comedy': 0.8, 'scifi': 0.9}
         ),
         classification.FewshotExampleMultiLabel(
             text='Superbad',
-            reasoning='A pure comedy about high school friends, no science fiction elements.',
             confidence_per_label={'comedy': 1.0, 'scifi': 0.0}
         ),
         classification.FewshotExampleMultiLabel(
             text='Blade Runner 2049',
-            reasoning='A serious dystopian sci-fi film with minimal comedic elements.',
             confidence_per_label={'comedy': 0.05, 'scifi': 1.0}
         ),
         classification.FewshotExampleMultiLabel(
             text='Guardians of the Galaxy',
-            reasoning='Space adventure with humor, aliens, and sci-fi action.',
             confidence_per_label={'comedy': 0.75, 'scifi': 0.9}
         ),
         classification.FewshotExampleMultiLabel(
             text='Interstellar',
-            reasoning='Hard science fiction about space exploration with emotional but not comedic tone.',
             confidence_per_label={'comedy': 0.05, 'scifi': 1.0}
         ),
     ]
@@ -157,32 +147,26 @@ def test_optimization_sentiment_analysis(optimizer) -> None:
     examples = [
         sentiment_analysis.FewshotExample(
             text='Great product, excellent quality and fast shipping!',
-            reasoning='Very positive review praising both product and service.',
             sentiment_per_aspect={'overall': 0.95, 'quality': 0.9, 'delivery': 0.95}
         ),
         sentiment_analysis.FewshotExample(
             text='Terrible quality, arrived damaged and late.',
-            reasoning='Very negative review criticizing quality and delivery.',
             sentiment_per_aspect={'overall': 0.1, 'quality': 0.05, 'delivery': 0.15}
         ),
         sentiment_analysis.FewshotExample(
             text='Decent product but shipping was slow.',
-            reasoning='Mixed review with average product quality and poor delivery.',
             sentiment_per_aspect={'overall': 0.5, 'quality': 0.6, 'delivery': 0.3}
         ),
         sentiment_analysis.FewshotExample(
             text='Amazing quality! Worth every penny.',
-            reasoning='Very positive review focused on quality.',
             sentiment_per_aspect={'overall': 0.95, 'quality': 1.0, 'delivery': 0.5}
         ),
         sentiment_analysis.FewshotExample(
             text='Not great, not terrible. Just okay.',
-            reasoning='Neutral review with average sentiment.',
             sentiment_per_aspect={'overall': 0.5, 'quality': 0.5, 'delivery': 0.5}
         ),
         sentiment_analysis.FewshotExample(
             text='Quick delivery but product quality is poor.',
-            reasoning='Mixed review with good delivery but bad quality.',
             sentiment_per_aspect={'overall': 0.4, 'quality': 0.2, 'delivery': 0.8}
         ),
     ]
@@ -324,7 +308,6 @@ def test_optimization_pii_masking(optimizer) -> None:
     examples = [
         pii_masking.FewshotExample(
             text='Please contact John Doe at john.doe@email.com for more information.',
-            reasoning='Contains a person name and email address that should be masked.',
             masked_text='Please contact [MASKED] at [MASKED] for more information.',
             pii_entities=[
                 pii_masking.PIIEntity(entity_type='NAME', text='John Doe'),
@@ -333,7 +316,6 @@ def test_optimization_pii_masking(optimizer) -> None:
         ),
         pii_masking.FewshotExample(
             text='Send the report to alice.smith@company.com by Friday.',
-            reasoning='Contains an email address.',
             masked_text='Send the report to [MASKED] by Friday.',
             pii_entities=[
                 pii_masking.PIIEntity(entity_type='EMAIL', text='alice.smith@company.com'),
@@ -341,7 +323,6 @@ def test_optimization_pii_masking(optimizer) -> None:
         ),
         pii_masking.FewshotExample(
             text='Call Bob Johnson at the office tomorrow.',
-            reasoning='Contains a person name.',
             masked_text='Call [MASKED] at the office tomorrow.',
             pii_entities=[
                 pii_masking.PIIEntity(entity_type='NAME', text='Bob Johnson'),
@@ -349,7 +330,6 @@ def test_optimization_pii_masking(optimizer) -> None:
         ),
         pii_masking.FewshotExample(
             text='Sarah Miller will attend the meeting.',
-            reasoning='Contains a person name.',
             masked_text='[MASKED] will attend the meeting.',
             pii_entities=[
                 pii_masking.PIIEntity(entity_type='NAME', text='Sarah Miller'),
@@ -357,7 +337,6 @@ def test_optimization_pii_masking(optimizer) -> None:
         ),
         pii_masking.FewshotExample(
             text='Email the document to michael.brown@org.net and copy jane.white@org.net.',
-            reasoning='Contains two email addresses.',
             masked_text='Email the document to [MASKED] and copy [MASKED].',
             pii_entities=[
                 pii_masking.PIIEntity(entity_type='EMAIL', text='michael.brown@org.net'),
@@ -366,7 +345,6 @@ def test_optimization_pii_masking(optimizer) -> None:
         ),
         pii_masking.FewshotExample(
             text='The meeting is scheduled for 2pm.',
-            reasoning='No PII present in this text.',
             masked_text='The meeting is scheduled for 2pm.',
             pii_entities=[]
         ),
@@ -438,17 +416,14 @@ def test_optimization_information_extraction(optimizer) -> None:
     examples = [
         information_extraction.FewshotExample(
             text='Alice Johnson is a 28-year-old software engineer.',
-            reasoning='Extract person information from bio.',
             entities=[Person(name='Alice Johnson', age=28, occupation='software engineer')]
         ),
         information_extraction.FewshotExample(
             text='Bob Smith, age 35, works as a teacher.',
-            reasoning='Extract person information from bio.',
             entities=[Person(name='Bob Smith', age=35, occupation='teacher')]
         ),
         information_extraction.FewshotExample(
             text='The team includes Sarah Lee (42, doctor) and Mike Brown (30, lawyer).',
-            reasoning='Extract multiple people from text.',
             entities=[
                 Person(name='Sarah Lee', age=42, occupation='doctor'),
                 Person(name='Mike Brown', age=30, occupation='lawyer'),
@@ -456,17 +431,14 @@ def test_optimization_information_extraction(optimizer) -> None:
         ),
         information_extraction.FewshotExample(
             text='Emma Davis is 25 and works as a designer.',
-            reasoning='Extract person information.',
             entities=[Person(name='Emma Davis', age=25, occupation='designer')]
         ),
         information_extraction.FewshotExample(
             text='Dr. John Williams, a 50-year-old researcher, published a new paper.',
-            reasoning='Extract person with title.',
             entities=[Person(name='Dr. John Williams', age=50, occupation='researcher')]
         ),
         information_extraction.FewshotExample(
             text='The company hired Lisa Chen (27) as an analyst.',
-            reasoning='Extract person information.',
             entities=[Person(name='Lisa Chen', age=27, occupation='analyst')]
         ),
     ]
@@ -658,39 +630,33 @@ def test_optimization_question_answering(optimizer) -> None:
     examples = [
         question_answering.FewshotExample(
             text='Albert Einstein developed the theory of relativity in 1915. His work revolutionized modern physics.',
-            reasoning='Extract information about Einstein and relativity.',
             questions=questions,
             answers=['The theory of relativity', 'Albert Einstein']
         ),
         question_answering.FewshotExample(
             text='Marie Curie won two Nobel Prizes for her research on radioactivity. She was the first woman to win a Nobel Prize.',
-            reasoning='Extract information about Curie and her achievements.',
             questions=questions,
             answers=['Research on radioactivity and Nobel Prizes', 'Marie Curie']
         ),
         question_answering.FewshotExample(
             text='Shakespeare wrote Romeo and Juliet in 1597. The play is one of the most famous love stories in '
                  'literature.',
-            reasoning='Extract information about Shakespeare and Romeo and Juliet.',
             questions=questions,
             answers=['Romeo and Juliet play', 'Shakespeare']
         ),
         question_answering.FewshotExample(
             text='The Amazon rainforest is home to millions of species. Deforestation threatens this biodiversity.',
-            reasoning='Extract information about Amazon and biodiversity.',
             questions=questions,
             answers=['Amazon rainforest biodiversity and deforestation', 'No specific people mentioned']
         ),
         question_answering.FewshotExample(
             text='Neil Armstrong became the first person to walk on the moon in 1969. This historic event was part of '
                  'the Apollo 11 mission.',
-            reasoning='Extract information about moon landing and Armstrong.',
             questions=questions,
             answers=['First moon landing', 'Neil Armstrong']
         ),
         question_answering.FewshotExample(
             text='Leonardo da Vinci painted the Mona Lisa during the Renaissance. He was also an inventor and scientist.',
-            reasoning='Extract information about da Vinci and his work.',
             questions=questions,
             answers=['The Mona Lisa painting', 'Leonardo da Vinci']
         ),


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Removes all `reasoning` fields in task signatures. We consider this superfluous given today's generative models inbuilt steerable reasoning levels.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
- Resolves #204.

## Changes Made
<!-- List key changes in this PR -->
- Removes `reasoning` fields in code and docs.

## Checklist
- [x] Tests have been extended to cover changes in functionality
- [ ] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
