### PR TITLE
fix: Suppress import warnings caused by `marker`

### DIFF
--- a/sieves/tasks/preprocessing/ingestion/marker_.py
+++ b/sieves/tasks/preprocessing/ingestion/marker_.py
@@ -1,8 +1,17 @@
 """Marker task for converting PDF documents to text."""
+# ruff: noqa: E402
 
+import warnings
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
+
+# `marker` is using outdated Pydantic config approach, suppress these warnings.
+warnings.filterwarnings(
+    "ignore",
+    message="Support for class-based `config` is deprecated.*ConfigDict instead",
+    category=DeprecationWarning,
+)
 
 from marker.converters.pdf import PdfConverter
 from marker.converters.table import TableConverter


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Fix warnings on Sieves imports caused by `marker`'s use of deprecated Pydantic config class.

## Related Issues
<!-- Link related issues using 'Fixes #issue_number' or 'Resolves #issue_number' -->
- Resolves #203.

## Changes Made
<!-- List key changes in this PR -->
- Suppresses Pydantic warnings for Marker import.

## Checklist
- [x] Tests have been extended to cover changes in functionality
- [x] Existing and new tests succeed
- [x] Documentation updated (if applicable)
- [x] Related issues linked

## Screenshots/Examples (if applicable)
<!-- Add screenshots or examples of functionality -->
