### PR TITLE
Fix demo API compatibility with sieves Result schemas

### DIFF
--- a/demos/demo_chatcontrol.py
+++ b/demos/demo_chatcontrol.py
@@ -245,8 +245,8 @@ def _(mo):
 
 @app.cell
 def _(result):
-    for article in result["InformationExtraction"]:
-        print(article)
+    for article in result["InformationExtraction"].entities:
+        print(article.topic)
         print(f"{article.link}")
         print("#######")
     return


### PR DESCRIPTION
## Summary
Fixes API compatibility issues in the marimo demo notebooks to correctly access Result object attributes.

## Changes
- **demo_chatcontrol.py**:
  - Fix QuestionAnswering result access to show individual Q&A pairs
  - Fix InformationExtraction iteration to access `.entities` attribute

## Testing
- Manually tested with marimo in browser
- Verified against current sieves API schemas

## Related Issues
Fixes issues discovered during demo usage where Result objects were not being accessed according to their Pydantic schema structure.

## Commits
1. `fix(demos): Access individual Q&A pairs in chatcontrol demo` - Display individual Q&A pairs instead of full list
2. `fix(demos): Access entities attribute in InformationExtraction result` - Fixes AttributeError when iterating over InformationExtraction results